### PR TITLE
USB Channel state tracker

### DIFF
--- a/libraries/TinyUSB_Devices/TinyUSB_Devices.cpp
+++ b/libraries/TinyUSB_Devices/TinyUSB_Devices.cpp
@@ -103,6 +103,10 @@ void AbsMouse5_::report(void)
 	buffer[2] = (_x >> 8) & 0xFF;
 	buffer[3] = _y & 0xFF;
 	buffer[4] = (_y >> 8) & 0xFF;
+    if(TinyUSBDevices.USBChannelLast != TinyUSBDevices.USBChannel_Mouse) {
+      delay(1);
+      TinyUSBDevices.USBChannelLast = TinyUSBDevices.USBChannel_Mouse;
+    }
 #if defined(_USING_HID)
 	HID().SendReport(_reportId, buffer, 5);
 #endif // _USING_HID
@@ -156,6 +160,10 @@ void AbsMouse5_::release(uint8_t button)
       USBDevice.remoteWakeup();
     }
     while(!usbHid.ready()) delay(1);
+    if(TinyUSBDevices.USBChannelLast != TinyUSBDevices.USBChannel_Keyboard) {
+      delay(1);
+      TinyUSBDevices.USBChannelLast = TinyUSBDevices.USBChannel_Keyboard;
+    }
     usbHid.keyboardReport(KeyboardReportID,keys->modifiers,keys->keys);
   }
   
@@ -457,6 +465,10 @@ void AbsMouse5_::release(uint8_t button)
       USBDevice.remoteWakeup();
     }
     while(!usbHid.ready()) delay(1);
+    if(TinyUSBDevices.USBChannelLast != TinyUSBDevices.USBChannel_Gamepad) {
+      delay(1);
+      TinyUSBDevices.USBChannelLast = TinyUSBDevices.USBChannel_Gamepad;
+    }
     tud_hid_report(HID_RID_GAMEPAD, &gamepad16Report, sizeof(gamepad16Report));
   }
 

--- a/libraries/TinyUSB_Devices/TinyUSB_Devices.h
+++ b/libraries/TinyUSB_Devices/TinyUSB_Devices.h
@@ -51,6 +51,12 @@ class TinyUSBDevices_ {
 public:
   TinyUSBDevices_(void);
   void begin(byte polRate);
+  enum USBChannelType_e {
+    USBChannel_Mouse = 0,
+    USBChannel_Keyboard,
+    USBChannel_Gamepad
+  };
+  uint8_t USBChannelLast = USBChannel_Mouse;
 };
 extern TinyUSBDevices_ TinyUSBDevices;
 


### PR DESCRIPTION
Because of the way HID reports works, if two messages from any two or more of the three profiles (the mouse, keyboard, and gamepad "slots" reported to the PC) are sent, one will override all the rest - this currently leads to dropped inputs, or buttons getting held stuck.

With this commit, when a report of one type is used, we now record whatever profile was last being reported. If any of the three types of reports are triggered, and differs from the last profile that was sent, we intentionally wait 1ms before reporting on the new channel.

Paired with 1ms polling, this seems to resolve any possibility of dropouts (really, how many people are pressing more than three buttons at once?) - though this is just a band-aid solution for the moment. Perhaps autoreport should be disabled and we just handle that separately after polling?