### PR TITLE
remove .dtr methon on Serial.dtr()

### DIFF
--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -1430,7 +1430,9 @@ void ExecRunMode()
                 unsigned long t = millis();
                 if(t - pauseHoldStartstamp > SamcoPreferences::settings.pauseHoldLength) {
                     // MAKE SURE EVERYTHING IS DISENGAGED:
-                    #ifdef USES_SOLENOID
+                    OF_FFB.FFBShutdown();
+					/*
+					#ifdef USES_SOLENOID
                         digitalWrite(SamcoPreferences::pins.oSolenoid, LOW);
                         solenoidFirstShot = false;
                     #endif // USES_SOLENOID
@@ -1439,14 +1441,17 @@ void ExecRunMode()
                         rumbleHappening = false;
                         rumbleHappened = false;
                     #endif // USES_RUMBLE
-                    Keyboard.releaseAll();
+                    */
+					Keyboard.releaseAll();
                     AbsMouse5.releaseAll();
                     offscreenBShot = false;
                     buttonPressed = false;
-                    triggerHeld = false;
+                    /*
+					triggerHeld = false;
                     burstFiring = false;
                     burstFireCount = 0;
-                    pauseModeSelection = PauseMode_Calibrate;
+                    */
+					pauseModeSelection = PauseMode_Calibrate;
                     SetMode(GunMode_Pause);
                     buttons.ReportDisable();
                     return;
@@ -1455,7 +1460,9 @@ void ExecRunMode()
         } else {
             if(buttons.pressedReleased == EnterPauseModeBtnMask || buttons.pressedReleased == BtnMask_Home) {
                 // MAKE SURE EVERYTHING IS DISENGAGED:
-                #ifdef USES_SOLENOID
+                OF_FFB.FFBShutdown();
+				/*
+				#ifdef USES_SOLENOID
                     digitalWrite(SamcoPreferences::pins.oSolenoid, LOW);
                     solenoidFirstShot = false;
                 #endif // USES_SOLENOID
@@ -1464,14 +1471,17 @@ void ExecRunMode()
                     rumbleHappening = false;
                     rumbleHappened = false;
                 #endif // USES_RUMBLE
-                Keyboard.releaseAll();
+                */
+				Keyboard.releaseAll();
                 AbsMouse5.releaseAll();
                 offscreenBShot = false;
                 buttonPressed = false;
-                triggerHeld = false;
+                /*
+				triggerHeld = false;
                 burstFiring = false;
                 burstFireCount = 0;
-                SetMode(GunMode_Pause);
+                */
+				SetMode(GunMode_Pause);
                 buttons.ReportDisable();
                 return;
             }

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -1431,8 +1431,8 @@ void ExecRunMode()
                 if(t - pauseHoldStartstamp > SamcoPreferences::settings.pauseHoldLength) {
                     // MAKE SURE EVERYTHING IS DISENGAGED:
                     OF_FFB.FFBShutdown();
-					/*
-					#ifdef USES_SOLENOID
+		    /*
+		    #ifdef USES_SOLENOID
                         digitalWrite(SamcoPreferences::pins.oSolenoid, LOW);
                         solenoidFirstShot = false;
                     #endif // USES_SOLENOID
@@ -1442,16 +1442,16 @@ void ExecRunMode()
                         rumbleHappened = false;
                     #endif // USES_RUMBLE
                     */
-					Keyboard.releaseAll();
+		    Keyboard.releaseAll();
                     AbsMouse5.releaseAll();
                     offscreenBShot = false;
                     buttonPressed = false;
                     /*
-					triggerHeld = false;
+		    triggerHeld = false;
                     burstFiring = false;
                     burstFireCount = 0;
                     */
-					pauseModeSelection = PauseMode_Calibrate;
+	    	    pauseModeSelection = PauseMode_Calibrate;
                     SetMode(GunMode_Pause);
                     buttons.ReportDisable();
                     return;
@@ -1461,8 +1461,8 @@ void ExecRunMode()
             if(buttons.pressedReleased == EnterPauseModeBtnMask || buttons.pressedReleased == BtnMask_Home) {
                 // MAKE SURE EVERYTHING IS DISENGAGED:
                 OF_FFB.FFBShutdown();
-				/*
-				#ifdef USES_SOLENOID
+		/*
+		#ifdef USES_SOLENOID
                     digitalWrite(SamcoPreferences::pins.oSolenoid, LOW);
                     solenoidFirstShot = false;
                 #endif // USES_SOLENOID
@@ -1472,16 +1472,16 @@ void ExecRunMode()
                     rumbleHappened = false;
                 #endif // USES_RUMBLE
                 */
-				Keyboard.releaseAll();
+		Keyboard.releaseAll();
                 AbsMouse5.releaseAll();
                 offscreenBShot = false;
                 buttonPressed = false;
                 /*
-				triggerHeld = false;
+		triggerHeld = false;
                 burstFiring = false;
                 burstFireCount = 0;
                 */
-				SetMode(GunMode_Pause);
+		SetMode(GunMode_Pause);
                 buttons.ReportDisable();
                 return;
             }

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -4078,7 +4078,7 @@ void PrintResults()
         return;
     }
 
-    if(!Serial.dtr()) {
+    if(!Serial) {
         stateFlags |= StateFlagsDtrReset;
         return;
     }
@@ -4113,7 +4113,7 @@ void PrintResults()
 // Subroutine that prints all stored preferences information in a table
 void PrintPreferences()
 {
-    if(!(stateFlags & StateFlag_PrintPreferences) || !Serial.dtr()) {
+    if(!(stateFlags & StateFlag_PrintPreferences) || !Serial) {
         return;
     }
 
@@ -4954,7 +4954,7 @@ void UpdateBindings(bool offscreenEnable)
 void PrintDebugSerial()
 {
     // only print every second
-    if(millis() - serialDbMs >= 1000 && Serial.dtr()) {
+    if(millis() - serialDbMs >= 1000 && Serial) {
         Serial.print("mode ");
         Serial.print(gunMode);
         Serial.print(", IR pos fps ");


### PR DESCRIPTION
removed .dtr method for greater compatibility, even with later versions of the library and with other mcu (I checked by looking at the library code and it's exactly the same thing)