### PR TITLE
Throttle camera error messages

### DIFF
--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -2176,8 +2176,19 @@ void GetPosition()
             }
         }
     } else if(error != DFRobotIRPositionEx::Error_DataMismatch) {
-        Serial.println("Device not available!");
+        SendCameraErrorMessage();
     }
+}
+
+void SendCameraErrorMessage(void)
+{
+  static unsigned long lastMillis = 0;
+  unsigned long currentMillis = millis();
+
+  if ( (currentMillis - lastMillis > 200) || (lastMillis == 0) ) {
+    Serial.println("Device not available!");
+    lastMillis = currentMillis;
+  }
 }
 
 // wait up to given amount of time for no buttons to be pressed before setting the mode


### PR DESCRIPTION
The "Device not available" error message is printed so fast that the OpenFIRE app cannot start. This will happen if the app is used with a microcontroller board that does not have a camera attached to the default GPIO pins used for the camera SDA and SCL. Without being able to start the OpenFIRE app, the pin assignments cannot be changed. This change prevents the error message from being printed less than every 200msec.

The app may need to be changed so that the IR Camera Tester checks for a "Device not available" error before opening the test screen. Similarly, the Calibrate Profile should check for the same error before starting. 