### PR TITLE
Improve IR Test Mode Output Efficiency by Buffering Serial Output

### DIFF
--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -80,7 +80,7 @@
   // Enables input processing on the second core, if available. Currently exclusive to Raspberry Pi Pico, or boards based on the RP2040.
   // Isn't necessarily faster, but might make responding to force feedback more consistent.
   // If unsure, leave this uncommented - it only affects RP2040 anyways.
-#define DUAL_CORE
+//#define DUAL_CORE
 
   // Here we define the Manufacturer Name/Device Name/PID:VID of the gun as will be displayed by the operating system.
   // For multiplayer, different guns need different IDs!
@@ -92,19 +92,19 @@
 
   // Set what player this board is mapped to by default (1-4). This will change keyboard mappings appropriate for the respective player.
   // If unsure, just leave this at 1 - the mapping can be changed at runtime by sending an 'XR#' command over Serial, where # = player number
-#define PLAYER_NUMBER 1
+//#define PLAYER_NUMBER 1
 
   // Leave this uncommented to enable MAMEHOOKER support, or comment out (//) to disable references to serial reading and only use it for debugging.
   // WARNING: Has a chance of making the board lock up if TinyUSB hasn't been patched to fix serial-related lockups.
   // If you're building this for RP2040, please make sure that you have NOT installed the TinyUSB library.
   // If unsure, leave uncommented - serial activity is used for configuration, and undefining this will cause errors.
-#define MAMEHOOKER
+//#define MAMEHOOKER
 
   // Leave this uncommented if your build uses hardware switches, or comment out to disable all references to hw switch functionality.
-#define USES_SWITCHES
+//#define USES_SWITCHES
 
   // Leave this uncommented if your build uses a rumble motor; comment out to disable any references to rumble functionality.
-#define USES_RUMBLE
+//#define USES_RUMBLE
 
   // Leave this uncommented if your build uses a solenoid, or comment out to disable any references to solenoid functionality.
 //#define USES_SOLENOID
@@ -114,23 +114,23 @@
 #endif // USES_SOLENOID
 
   // Leave this uncommented if your build uses an analog stick.
-#define USES_ANALOG
+//#define USES_ANALOG
 
   // Leave this uncommented if your build uses a four pin RGB LED.
-#define FOURPIN_LED
+//#define FOURPIN_LED
 #ifdef FOURPIN_LED
     #define LED_ENABLE
 #endif // FOURPIN_LED
 
   // Leave this uncommented if your build uses an external NeoPixel.
-#define CUSTOM_NEOPIXEL
+//#define CUSTOM_NEOPIXEL
 #ifdef CUSTOM_NEOPIXEL
     #define LED_ENABLE
     #include <Adafruit_NeoPixel.h>
 #endif // CUSTOM_NEOPIXEL
 
   // Leave this uncommented to enable optional support for SSD1306 monochrome OLED displays.
-#define USES_DISPLAY
+//#define USES_DISPLAY
 #ifdef USES_DISPLAY
   #include "SamcoDisplay.h"
 #endif // USES_DISPLAY

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -312,13 +312,6 @@ int moveXAxisArr[3] = {0, 0, 0};
 int moveYAxisArr[3] = {0, 0, 0};
 int moveIndex = 0;
 
-int32_t mouseCurrentX;
-int32_t mouseCurrentY;
-int32_t mouseTargetX;
-int32_t mouseTargetY;
-bool mouseMoving = false;
-
-
 // For offscreen button stuff:
 bool offscreenButton = false;                    // Does shooting offscreen also send a button input (for buggy games that don't recognize off-screen shots)? Default to off.
 bool offscreenBShot = false;                     // For offscreenButton functionality, to track if we shot off the screen.

--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -2149,26 +2149,29 @@ void GetPosition()
                     }
                 }
                 if(runMode == RunMode_Processing) {
-                    for(int i = 0; i < 4; i++) {
-                        Serial.print(rawX[i]);
-                        Serial.print( "," );
-                        Serial.print(rawY[i]);
-                        Serial.print( "," );
-                    }
-                    Serial.print( mouseX / 4 );
-                    Serial.print( "," );
-                    Serial.print( mouseY / 4 );
-                    Serial.print( "," );
-                    // Median for viewing in processing
-                    if(profileData[selectedProfile].irLayout) {
-                        Serial.print(map(OpenFIREdiamond.testMedianX(), 0, 1023 << 2, 1920, 0));
-                        Serial.print( "," );
-                        Serial.println(map(OpenFIREdiamond.testMedianY(), 0, 768 << 2, 0, 1080));
-                    } else {
-                        Serial.print(map(OpenFIREsquare.testMedianX(), 0, 1023 << 2, 0, 1920));
-                        Serial.print( "," );
-                        Serial.println(map(OpenFIREsquare.testMedianY(), 0, 768 << 2, 0, 1080));
-                    }
+
+                  char buffer[128];
+                  int pos = 0;
+			
+                  for (int i = 0; i < 4; i++) {
+                    pos += sprintf(buffer + pos, "%d,", rawX[i]);
+                    pos += sprintf(buffer + pos, "%d,", rawY[i]);
+                  }
+    
+                  pos += sprintf(buffer + pos, "%d,", mouseX / 4);
+                  pos += sprintf(buffer + pos, "%d,", mouseY / 4);
+    
+                  if (profileData[selectedProfile].irLayout) {
+                    int medianX = map(OpenFIREdiamond.testMedianX(), 0, 4092, 1920, 0);
+                    int medianY = map(OpenFIREdiamond.testMedianY(), 0, 3072, 0, 1080);
+                    pos += sprintf(buffer + pos, "%d,%d\n", medianX, medianY);
+                  } else {
+                    int medianX = map(OpenFIREsquare.testMedianX(), 0, 4092, 0, 1920);
+                    int medianY = map(OpenFIREsquare.testMedianY(), 0, 3072, 0, 1080);
+                    pos += sprintf(buffer + pos, "%d,%d\n", medianX, medianY);
+                  }
+			
+                  Serial.print(buffer);
                 }
                 #ifdef USES_DISPLAY
                     OLED.DrawVisibleIR(rawX, rawY);


### PR DESCRIPTION
I noticed that the multiple Serial.print calls in the IR Camera Test mode were noticeably slowing down the test point outputs. So I consolidated all the output into a single buffer. It's a lot smoother now :)