### PR TITLE
Update SamcoPreferences.cpp and OpenFIREFeedback.cpp

### DIFF
--- a/SamcoEnhanced/OpenFIREFeedback.cpp
+++ b/SamcoEnhanced/OpenFIREFeedback.cpp
@@ -107,7 +107,7 @@ void OF_FFB::FFBRelease()
     // If Rumble FF is enabled and Autofire is enabled, the motor needs to be disabled when the trigger is released. Otherwise, allow RumbleActivation to deal with the activation timer
     if(SamcoPreferences::toggles[OF_Const::rumbleFF] && SamcoPreferences::toggles[OF_Const::autofire]) {
         if(rumbleHappening || rumbleHappened) {
-            digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], LOW);      // Make sure the rumble is OFF.
+            analogWrite(SamcoPreferences::pins[OF_Const::rumblePin], 0);      // Make sure the rumble is OFF.
             rumbleHappening = false;                                // This rumble command is done now.
             rumbleHappened = false;                                 // Make it clear we've stopped holding.
         }
@@ -208,14 +208,14 @@ void OF_FFB::RumbleActivation()
         if(SamcoPreferences::toggles[OF_Const::rumbleFF]) {
             if(!SamcoPreferences::toggles[OF_Const::autofire]) {       // We only want to use the rumble timer if Autofire is not active. Otherwise, keep it going
                 if(currentMillis - previousMillisRumble >= SamcoPreferences::settings[OF_Const::rumbleInterval] / 2) { // If we've been waiting long enough for this whole rumble command,
-                    digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], LOW);                         // Make sure the rumble is OFF.
+                    analogWrite(SamcoPreferences::pins[OF_Const::rumblePin], 0);                         // Make sure the rumble is OFF.
                     rumbleHappening = false;                              // This rumble command is done now.
                     rumbleHappened = true;                                // And just to make sure, to prevent holding == repeat rumble commands.
                 }
             }
         } else {
             if(currentMillis - previousMillisRumble >= SamcoPreferences::settings[OF_Const::rumbleInterval]) { // If we've been waiting long enough for this whole rumble command,
-                digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], LOW);                         // Make sure the rumble is OFF.
+                analogWrite(SamcoPreferences::pins[OF_Const::rumblePin], 0);                         // Make sure the rumble is OFF.
                 rumbleHappening = false;                              // This rumble command is done now.
                 rumbleHappened = true;                                // And just to make sure, to prevent holding == repeat rumble commands.
             }
@@ -253,7 +253,7 @@ void OF_FFB::BurstFire()
 void OF_FFB::FFBShutdown()
 {
     digitalWrite(SamcoPreferences::pins[OF_Const::solenoidPin], LOW);
-    digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], LOW);
+    analogWrite(SamcoPreferences::pins[OF_Const::rumblePin], 0);
     solenoidFirstShot = false;
     rumbleHappening = false;
     rumbleHappened = false;

--- a/SamcoEnhanced/OpenFIREcommon.cpp
+++ b/SamcoEnhanced/OpenFIREcommon.cpp
@@ -566,11 +566,11 @@ void FW_Common::ExecCalMode(const bool &fromDesktop)
         if(SamcoPreferences::toggles[OF_Const::rumble]) {
             analogWrite(SamcoPreferences::pins[OF_Const::rumblePin], SamcoPreferences::settings[OF_Const::rumbleStrength]);
             delay(80);
-            digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], false);
+            digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], LOW);
             delay(50);
             analogWrite(SamcoPreferences::pins[OF_Const::rumblePin], SamcoPreferences::settings[OF_Const::rumbleStrength]);
             delay(125);
-            digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], false);
+            digitalWrite(SamcoPreferences::pins[OF_Const::rumblePin], LOW);
         }
     #endif // USES_RUMBLE
 

--- a/SamcoEnhanced/OpenFIREserial.cpp
+++ b/SamcoEnhanced/OpenFIREserial.cpp
@@ -1241,7 +1241,7 @@ void OF_Serial::SerialProcessingDocked()
                     serialInput = Serial.read();
                     if(serialInput >= '0' && serialInput <= '3') {
                         uint8_t i = serialInput - '0';
-                        Serial.printf("%i,%i,%i,%i,%.2f,%.2f,%i,%i,%i,%i,",
+                        Serial.printf("%i,%i,%i,%i,%.2f,%.2f,%i,%i,%i,%i,%s\r\n",
                         FW_Common::profileData[i].topOffset,
                         FW_Common::profileData[i].bottomOffset,
                         FW_Common::profileData[i].leftOffset,
@@ -1251,18 +1251,15 @@ void OF_Serial::SerialProcessingDocked()
                         FW_Common::profileData[i].irSensitivity,
                         FW_Common::profileData[i].runMode,
                         FW_Common::profileData[i].irLayout,
-                        FW_Common::profileData[i].color
+                        FW_Common::profileData[i].color,
+			FW_Common::profileData[i].name	
                         );
-                        Serial.println(FW_Common::profileData[i].name);
                     }
                     break;
                   #ifdef USE_TINYUSB
                   case 'i':
-                    Serial.printf("%i,",SamcoPreferences::usb.devicePID);
-                    if(SamcoPreferences::usb.deviceName[0] == '\0')
-                        Serial.println("SERIALREADERR01");
-                    else Serial.println(SamcoPreferences::usb.deviceName);
-                    break;
+                    Serial.printf("%i,%s\r\n",SamcoPreferences::usb.devicePID, (SamcoPreferences::usb.deviceName[0] == '\0') ? "SERIALREADERR01" : SamcoPreferences::usb.deviceName);
+		    break;
                   #endif // USE_TINYUSB
                 }
                 break;

--- a/SamcoEnhanced/SamcoPreferences.cpp
+++ b/SamcoEnhanced/SamcoPreferences.cpp
@@ -60,7 +60,7 @@ int SamcoPreferences::LoadProfiles()
 int SamcoPreferences::SaveProfiles()
 {
     WriteHeader();
-    EEPROM.update(4, FW_Common::profiles.selectedProfile);
+    EEPROM.put(4, FW_Common::profiles.selectedProfile);
     uint8_t* p = ((uint8_t*)FW_Common::profiles.pProfileData);
     for(unsigned int i = 0; i < sizeof(ProfileData_t) * FW_Common::profiles.profileCount; ++i)
         EEPROM.write(5 + i, p[i]);
@@ -141,7 +141,7 @@ int SamcoPreferences::SaveUSBID()
 void SamcoPreferences::ResetPreferences()
 {
     for(uint16_t i = 0; i < EEPROM.length(); ++i)
-        EEPROM.update(i, 0);
+        EEPROM.put(i, 0);
 
     EEPROM.commit();
 }

--- a/libraries/LightgunButtons/LightgunButtons.cpp
+++ b/libraries/LightgunButtons/LightgunButtons.cpp
@@ -336,12 +336,6 @@ void LightgunButtons::PadMaskConvert()
         case 10: // 0x00001010
             padMaskConv = GAMEPAD_HAT_DOWN_RIGHT;
             break;
-        case 3: // 0x00000011
-            padMaskConv = GAMEPAD_HAT_UP;
-            break;
-        case 12: // 0x00001100
-            padMaskConv = GAMEPAD_HAT_LEFT;
-            break;
         default: // 0x00000000
             padMaskConv = GAMEPAD_HAT_CENTERED;
             break;


### PR DESCRIPTION
x SamcoPreferences.cpp
The EEPROM.update method does not exist in other EEPROM libraries such as the one for the esp32, while the EEPROM.put method exists for all libraries. The EEPROM.update method in rp2040 does nothing but call the EEPROM.put method and nothing more. I have adapted OpenFIRE to work also on EPS32 and if there are no problems, I ask the courtesy of making this small change that does not affect the operation.

x OpenFIREFeedback.cpp
The rumble pin is used in analog PWM mode, therefore analogWrite must be used and not digitalWrite and even though with the library for rp2040 it still works when the low level of the pin is set (with this library it is equivalent to writing analogWrite(pin, 0)), with other micros such as esp32 it does not work and you must use analogWrite setting the value to 0. Therefore I ask the courtesy, since I have adapted OpenFire to also work with esp32, to make this modification, which does not involve anything different in the operation. I have tested it both on rp2040 and on esp32 and with analogWrite it works well with both micros.