### PR TITLE
Update LightgunButtons.cpp

### DIFF
--- a/libraries/LightgunButtons/LightgunButtons.cpp
+++ b/libraries/LightgunButtons/LightgunButtons.cpp
@@ -336,12 +336,6 @@ void LightgunButtons::PadMaskConvert()
         case 10: // 0x00001010
             padMaskConv = GAMEPAD_HAT_DOWN_RIGHT;
             break;
-        case 3: // 0x00000011
-            padMaskConv = GAMEPAD_HAT_UP;
-            break;
-        case 12: // 0x00001100
-            padMaskConv = GAMEPAD_HAT_LEFT;
-            break;
         default: // 0x00000000
             padMaskConv = GAMEPAD_HAT_CENTERED;
             break;


### PR DESCRIPTION
Except for the conditions that should never occur and in any case it would probably be more logical to set the central position (default)