### PR TITLE
Update SamcoEnhanced.ino

### DIFF
--- a/SamcoEnhanced/SamcoEnhanced.ino
+++ b/SamcoEnhanced/SamcoEnhanced.ino
@@ -101,12 +101,11 @@ void setup() {
     #endif // LED_ENABLE
     
 #ifdef USE_TINYUSB
-    TUSBDeviceSetup;
     #if defined(ARDUINO_RASPBERRY_PI_PICO_W) && defined(ENABLE_CLASSIC)
     // is VBUS (USB voltage) detected?
     if(digitalRead(34)) {
         // If so, we're connected via USB, so initializing the USB devices chunk.
-        TUSBDeviceSetup.begin(1);
+        TinyUSBDevices.begin(1);
         // wait until device mounted
         while(!USBDevice.mounted()) { yield(); }
         Serial.begin(9600);


### PR DESCRIPTION
Removed 'TUSBDeviceSetup' and put back 'TinyUSBDevices', or did you just start the replacement and want to remove all the 'TinyUSBDevices' to replace them with the new 'TUSBDeviceSetup'? .. otherwise, I don't see the point, but maybe it's me who can't understand it because I'm an idiot. It also works with 'TUSBDeviceSetup' but put like this it doesn't make sense, at least I think so