### PR TITLE
Add support for generating Wii Camera Clock pulse from an RP2040 pin

### DIFF
--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -8,6 +8,12 @@
 
 #include <Arduino.h>
 #include <Wire.h>
+#ifdef ARDUINO_ARCH_RP2040
+  // for RP2040 Wii Clock Gen
+  #include <pico/stdlib.h>
+  #include <hardware/clocks.h>
+  #include <hardware/pwm.h>
+#endif // ARDUINO_ARCH_RP2040
 
 #include "OpenFIREcommon.h"
 #include "OpenFIRElights.h"
@@ -170,6 +176,25 @@ void FW_Common::CameraSet()
             dfrIRPos = new DFRobotIRPositionEx(Wire);
         }
     }
+
+    #ifdef ARDUINO_ARCH_RP2040
+    if(OF_Prefs::pins[OF_Const::wiiClockGen] > -1) {
+        set_sys_clock_khz(125000, true);
+        gpio_set_function(OF_Prefs::pins[OF_Const::wiiClockGen], GPIO_FUNC_PWM);
+        uint slice_num = pwm_gpio_to_slice_num(OF_Prefs::pins[OF_Const::wiiClockGen]);
+        pwm_set_clkdiv(slice_num, 1.0f);  // for sys_clock = 125MHz
+        //pwm_set_clkdiv(slice_num, 3.0f); // for sys_clock = 150MHz
+        pwm_set_wrap(slice_num, 4);
+        pwm_set_chan_level(slice_num, PWM_CHAN_A, 2);
+        pwm_set_enabled(slice_num, true);
+    } else {
+        set_sys_clock_khz(133000, true);
+        pwm_set_enabled(pwm_gpio_to_slice_num(OF_Prefs::pins[OF_Const::wiiClockGen]), false);
+        gpio_set_function(OF_Prefs::pins[OF_Const::wiiClockGen], GPIO_FUNC_SIO);
+        gpio_put(OF_Prefs::pins[OF_Const::wiiClockGen], 0);
+        gpio_set_dir(OF_Prefs::pins[OF_Const::wiiClockGen], GPIO_IN);
+    }
+    #endif // ARDUINO_ARCH_RP2040
 
     // Start IR Camera with basic data format
     if(dfrIRPos != nullptr) {

--- a/OpenFIREmain/OpenFIREprefs.cpp
+++ b/OpenFIREmain/OpenFIREprefs.cpp
@@ -378,7 +378,7 @@ void OF_Prefs::ResetPreferences()
 
 void OF_Prefs::LoadPresets()
 {
-    memset(pins, -1, OF_Const::boardInputsCount);
+    memset(pins, -1, sizeof(OF_Prefs::pins));
 
     if(OF_Const::boardsPresetsMap.count(OPENFIRE_BOARD)) {
         for(int i = 0; i < OF_Const::boardsPresetsMap.at(OPENFIRE_BOARD).size(); i++)

--- a/OpenFIREmain/OpenFIREprefs.cpp
+++ b/OpenFIREmain/OpenFIREprefs.cpp
@@ -378,13 +378,11 @@ void OF_Prefs::ResetPreferences()
 
 void OF_Prefs::LoadPresets()
 {
-    for(int i = 0; i < OF_Const::boardInputsCount; i++)
-        pins[i] = -1;
+    memset(pins, -1, OF_Const::boardInputsCount);
 
     if(OF_Const::boardsPresetsMap.count(OPENFIRE_BOARD)) {
         for(int i = 0; i < OF_Const::boardsPresetsMap.at(OPENFIRE_BOARD).size(); i++)
             if(OF_Const::boardsPresetsMap.at(OPENFIRE_BOARD).at(i) > -1)
                 pins[OF_Const::boardsPresetsMap.at(OPENFIRE_BOARD).at(i)] = i;
-    } else for(int i = 0; i < OF_Const::boardInputsCount; i++)
-        pins[i] = -1;
+    }
 }


### PR DESCRIPTION
This removes the need for an external quartz crystal for raw Wiimote cameras, so (if the user wishes) the whole thing can be wired directly to the board (assuming using 3.3V output) with just a single daisy-chain from Cam VCC in to its "enable" Pin, at the cost of one more conventional GPIO than a normal DFRobot or a quartz-based pulse setup. Requires App version TeamOpenFIRE/OpenFIRE-App@d9b813a to set this to a pin.

Closes #32