### PR TITLE
Add/expose custom temperature thresholds, show on OLED display when at idle

### DIFF
--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -167,7 +167,7 @@ void OF_FFB::SolenoidActivation(const int &solenoidFinalInterval)
 void OF_FFB::TemperatureUpdate()
 {
     currentMillis = millis();
-    if(currentMillis - previousMillisTemp > 2) {
+    if(currentMillis - previousMillisTemp > TEMP_UPDATE_INTERVAL) {
         previousMillisTemp = currentMillis;
         temperatureGraph[tempGraphIndex] = (((analogRead(OF_Prefs::pins[OF_Const::tempPin]) * 3.3) / 4096) - 0.5) * 100; // Convert reading from mV->3.3->12-bit->Celsius
         if(tempGraphIndex < 3) {

--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -137,7 +137,7 @@ void OF_FFB::SolenoidActivation(const int &solenoidFinalInterval)
                             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], !digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])); // Flip, flop.
                         }
                     } else { // The solenoid's probably off, not on right now. So that means we should wait a bit longer to fire again.
-                        if(currentMillis - previousMillisSol >= solenoidWarningInterval) { // We're keeping it low for a bit longer, to keep temps stable. Try to give it a bit of time to cool down before we go again.
+                        if(currentMillis - previousMillisSol >= (OF_Prefs::settings[OF_Const::solenoidFastInterval] << 2)) { // We're keeping it low for a bit longer, to keep temps stable. Try to give it a bit of time to cool down before we go again.
                             previousMillisSol = currentMillis;
                             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], !digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]));
                         }
@@ -169,32 +169,28 @@ void OF_FFB::TemperatureUpdate()
     currentMillis = millis();
     if(currentMillis - previousMillisTemp > 2) {
         previousMillisTemp = currentMillis;
-        temperatureGraph[temperatureIndex] = (((analogRead(OF_Prefs::pins[OF_Const::tempPin]) * 3.3) / 4096) - 0.5) * 100; // Convert reading from mV->3.3->12-bit->Celsius
-        if(temperatureIndex < 3) {
-            temperatureIndex++;
+        temperatureGraph[tempGraphIndex] = (((analogRead(OF_Prefs::pins[OF_Const::tempPin]) * 3.3) / 4096) - 0.5) * 100; // Convert reading from mV->3.3->12-bit->Celsius
+        if(tempGraphIndex < 3) {
+            tempGraphIndex++;
         } else {
             // average out temperature from four samples taken 3ms apart from each other
-            temperatureIndex = 0;
+            tempGraphIndex = 0;
             temperatureCurrent = (temperatureGraph[0] +
                                   temperatureGraph[1] +
                                   temperatureGraph[2] +
-                                  temperatureGraph[3]) / 4;
+                                  temperatureGraph[3]) >> 2;
+                                  
             if(tempStatus == Temp_Fatal) {
-                if(temperatureCurrent < tempWarning-5) {
+                if(temperatureCurrent < OF_Prefs::settings[OF_Const::tempShutdown]-5)
                     tempStatus = Temp_Warning;
-                }
             } else {
-                if(temperatureCurrent >= tempWarning) {
+                if(temperatureCurrent >= OF_Prefs::settings[OF_Const::tempShutdown])
                     tempStatus = Temp_Fatal;
-                } else if(tempStatus == Temp_Warning) {
-                    if(temperatureCurrent < tempNormal-5) {
+                else if(tempStatus == Temp_Warning) {
+                    if(temperatureCurrent < OF_Prefs::settings[OF_Const::tempWarning]-5)
                         tempStatus = Temp_Safe;
-                    }
-                } else {
-                    if(temperatureCurrent >= tempNormal) {
-                        tempStatus = Temp_Warning;
-                    }
-                }
+                } else if(temperatureCurrent >= OF_Prefs::settings[OF_Const::tempWarning])
+                    tempStatus = Temp_Warning;
             }
         }
     }

--- a/OpenFIREmain/OpenFIREFeedback.h
+++ b/OpenFIREmain/OpenFIREFeedback.h
@@ -25,7 +25,7 @@ public:
     static void SolenoidActivation(const int &);
 
     /// @brief Updates current temperature (averaged), if available
-    /// @details Only polls every 3ms, with updates committed to temperatureCurrent after four successful polling cycles
+    /// @details Only polls every 250ms, with updates committed to temperatureCurrent after four successful polling cycles
     static void TemperatureUpdate();
 
     /// @brief Subroutine managing rumble state
@@ -46,6 +46,8 @@ public:
 
     // Current temperature as read from TMP36, in (approximate) Celsius
     static inline uint temperatureCurrent;
+
+    #define TEMP_UPDATE_INTERVAL 250
 
 private:
     // For solenoid:

--- a/OpenFIREmain/OpenFIREFeedback.h
+++ b/OpenFIREmain/OpenFIREFeedback.h
@@ -62,18 +62,14 @@ private:
         Temp_Fatal
     };
 
-    static inline uint tempNormal = 35;                      // Solenoid: Anything below this value is "normal" operating temperature for the solenoid, in Celsius.
-    static inline uint tempWarning = 42;                     // Solenoid: Above normal temps, this is the value up to where we throttle solenoid activation, in Celsius.
-    static inline uint tempStatus = Temp_Safe;               // Current state of the solenoid,
+    static inline TempStatuses_e tempStatus = Temp_Safe;               // Current state of the solenoid,
 
     // timer stuff
     static inline unsigned long currentMillis = 0;           // Current millis() value, which is globally updated/read across all functions in this class
     static inline unsigned long previousMillisTemp = 0;      // Timestamp of last time TMP36 was read
 
-    static inline uint temperatureGraph[4];          // Table of collected (converted) TMP36 readings, to be averaged into temperatureCurrent on the fourth value.
-    static inline uint temperatureIndex = 0;                 // Current index of temperatureGraph to update; initiates temperatureCurrent update/averaging when = 3.
-
-    static inline uint solenoidWarningInterval = OF_Prefs::settings[OF_Const::solenoidFastInterval] * 5; // for if solenoid is getting toasty.
+    static inline int temperatureGraph[4];                  // Table of collected (converted) TMP36 readings, to be averaged into temperatureCurrent on the fourth value.
+    static inline uint tempGraphIndex = 0;                 // Current index of temperatureGraph to update; initiates temperatureCurrent update/averaging when = 3.
 
     // For burst firing stuff:
     static inline uint burstFireCount = 0;                   // What shot are we on?

--- a/OpenFIREmain/OpenFIREdisplay.cpp
+++ b/OpenFIREmain/OpenFIREdisplay.cpp
@@ -176,6 +176,8 @@ void ExtDisplay::IdleOps()
     if(display != nullptr) {
         switch(screenState) {
         case Screen_Normal:
+        case Screen_Mamehook_Single:
+        case Screen_Mamehook_Dual:
           #ifdef USES_TEMP
           if(OF_Prefs::pins[OF_Const::tempPin] > -1) {
               if(millis() - idleTimeStamp > OLED_IDLEUPD_INTERVAL) {
@@ -206,10 +208,6 @@ void ExtDisplay::IdleOps()
         case Screen_Saving:
           break;
         case Screen_Calibrating:
-          break;
-        case Screen_Mamehook_Single:
-          break;
-        case Screen_Mamehook_Dual:
           break;
         }
     }

--- a/OpenFIREmain/OpenFIREdisplay.cpp
+++ b/OpenFIREmain/OpenFIREdisplay.cpp
@@ -16,6 +16,8 @@
 
 #include "OpenFIREdisplay.h"
 #include "OpenFIREprefs.h"
+#include "OpenFIREFeedback.h"
+#include "OpenFIREDefines.h"
 
 bool ExtDisplay::Begin()
 {
@@ -81,6 +83,7 @@ void ExtDisplay::TopPanelUpdate(const char *textPrefix, const char *profText)
 void ExtDisplay::ScreenModeChange(int8_t screenMode, bool isAnalog)
 {
     if(display != nullptr) {
+        idleTimeStamp = millis();
         display->fillRect(0, 16, 128, 48, BLACK);
         if(screenState >= Screen_Mamehook_Single &&
            screenMode == Screen_Normal) {
@@ -171,21 +174,48 @@ void ExtDisplay::ScreenModeChange(int8_t screenMode, bool isAnalog)
 void ExtDisplay::IdleOps()
 {
     if(display != nullptr) {
-        switch(screenState) {
-          case Screen_Normal:
-            break;
-          case Screen_Pause:
-            break;
-          case Screen_Profile:
-            break;
-          case Screen_Saving:
-            break;
-          case Screen_Calibrating:
-            break;
-          case Screen_Mamehook_Single:
-            break;
-          case Screen_Mamehook_Dual:
-            break;
+        if(millis() - idleTimeStamp > OLED_IDLEUPD_INTERVAL) {
+            idleTimeStamp = millis();
+            switch(screenState) {
+            case Screen_Normal:
+              #ifdef USES_TEMP
+              if(OF_Prefs::pins[OF_Const::tempPin] > -1) {
+                  if(showingTemp) {
+                      TopPanelUpdate("Prof: ", OF_Prefs::profiles[OF_Prefs::currentProfile].name);
+                  } else {
+                      if(OF_FFB::temperatureCurrent < 10) {
+                          tempString[0] = OF_FFB::temperatureCurrent + '0';
+                          tempString[1] = ' ';
+                          tempString[2] = 'C';
+                          tempString[3] = '\0';
+                      } else {
+                          int tempLeft = OF_FFB::temperatureCurrent / 10;
+                          int tempRight = OF_FFB::temperatureCurrent - (tempLeft * 10);
+                          tempString[0] = tempLeft + '0';
+                          tempString[1] = tempRight + '0';
+                          tempString[2] = ' ';
+                          tempString[3] = 'C';
+                          tempString[4] = '\0';
+                      }
+                      TopPanelUpdate("Current Temp: ", tempString);
+                  }
+                  showingTemp = !showingTemp;
+              }
+              #endif // USES_TEMP
+              break;
+            case Screen_Pause:
+              break;
+            case Screen_Profile:
+              break;
+            case Screen_Saving:
+              break;
+            case Screen_Calibrating:
+              break;
+            case Screen_Mamehook_Single:
+              break;
+            case Screen_Mamehook_Dual:
+              break;
+            }
         }
     }
 }
@@ -452,7 +482,7 @@ void ExtDisplay::PrintAmmo(uint8_t ammo)
 
         // use the rounding error to get the left & right digits
         uint ammoLeft = ammo / 10;
-        uint ammoRight = ammo - ammoLeft * 10;
+        uint ammoRight = ammo - (ammoLeft * 10);
 
         if(!ammo) { ammoEmpty = true; } else { ammoEmpty = false; }
 

--- a/OpenFIREmain/OpenFIREdisplay.cpp
+++ b/OpenFIREmain/OpenFIREdisplay.cpp
@@ -174,51 +174,69 @@ void ExtDisplay::ScreenModeChange(int8_t screenMode, bool isAnalog)
 void ExtDisplay::IdleOps()
 {
     if(display != nullptr) {
-        if(millis() - idleTimeStamp > OLED_IDLEUPD_INTERVAL) {
-            idleTimeStamp = millis();
-            switch(screenState) {
-            case Screen_Normal:
-              #ifdef USES_TEMP
-              if(OF_Prefs::pins[OF_Const::tempPin] > -1) {
+        switch(screenState) {
+        case Screen_Normal:
+          #ifdef USES_TEMP
+          if(OF_Prefs::pins[OF_Const::tempPin] > -1) {
+              if(millis() - idleTimeStamp > OLED_IDLEUPD_INTERVAL) {
+                  idleTimeStamp = millis();
                   if(showingTemp) {
                       TopPanelUpdate("Prof: ", OF_Prefs::profiles[OF_Prefs::currentProfile].name);
+                      showingTemp = false;
                   } else {
-                      if(OF_FFB::temperatureCurrent < 10) {
-                          tempString[0] = OF_FFB::temperatureCurrent + '0';
-                          tempString[1] = ' ';
-                          tempString[2] = 'C';
-                          tempString[3] = '\0';
-                      } else {
-                          int tempLeft = OF_FFB::temperatureCurrent / 10;
-                          int tempRight = OF_FFB::temperatureCurrent - (tempLeft * 10);
-                          tempString[0] = tempLeft + '0';
-                          tempString[1] = tempRight + '0';
-                          tempString[2] = ' ';
-                          tempString[3] = 'C';
-                          tempString[4] = '\0';
-                      }
-                      TopPanelUpdate("Current Temp: ", tempString);
+                      idleTempStamp = idleTimeStamp;
+                      ShowTemp();
+                      showingTemp = true;
                   }
-                  showingTemp = !showingTemp;
+              } else if(showingTemp) {
+                  if(millis() - idleTempStamp > OLED_TEMPUPD_INTERVAL) {
+                      idleTempStamp = millis();
+                      if(currentTemp != OF_FFB::temperatureCurrent) {
+                          ShowTemp();
+                      }
+                  }
               }
-              #endif // USES_TEMP
-              break;
-            case Screen_Pause:
-              break;
-            case Screen_Profile:
-              break;
-            case Screen_Saving:
-              break;
-            case Screen_Calibrating:
-              break;
-            case Screen_Mamehook_Single:
-              break;
-            case Screen_Mamehook_Dual:
-              break;
-            }
+          }
+          #endif // USES_TEMP
+          break;
+        case Screen_Pause:
+          break;
+        case Screen_Profile:
+          break;
+        case Screen_Saving:
+          break;
+        case Screen_Calibrating:
+          break;
+        case Screen_Mamehook_Single:
+          break;
+        case Screen_Mamehook_Dual:
+          break;
         }
     }
 }
+
+#ifdef USES_TEMP
+void ExtDisplay::ShowTemp()
+{
+    if(OF_FFB::temperatureCurrent < 10) {
+        tempString[0] = OF_FFB::temperatureCurrent + '0';
+        tempString[1] = ' ';
+        tempString[2] = 'C';
+        tempString[3] = '\0';
+    } else {
+        int tempLeft = OF_FFB::temperatureCurrent / 10;
+        int tempRight = OF_FFB::temperatureCurrent - (tempLeft * 10);
+        tempString[0] = tempLeft + '0';
+        tempString[1] = tempRight + '0';
+        tempString[2] = ' ';
+        tempString[3] = 'C';
+        tempString[4] = '\0';
+    }
+
+    TopPanelUpdate("Current Temp: ", tempString);
+    currentTemp = OF_FFB::temperatureCurrent;
+}
+#endif // USES_TEMP
 
 // Warning: SLOOOOW, should only be used in cali/where the mouse isn't being updated.
 // Use at your own discression.

--- a/OpenFIREmain/OpenFIREdisplay.h
+++ b/OpenFIREmain/OpenFIREdisplay.h
@@ -110,10 +110,11 @@ private:
     bool ammoEmpty = false;
     bool lifeEmpty = false;
 
-    uint8_t currentAmmo;
-    uint8_t currentLife;
+    uint currentAmmo;
+    uint currentLife;
 
     #define OLED_IDLEUPD_INTERVAL 5000
+    #define OLED_TEMPUPD_INTERVAL 750
 
     // timestamps for periodic tasks in IdleOps()
     unsigned long ammoTimestamp = 0;
@@ -121,6 +122,10 @@ private:
     unsigned long idleTimeStamp = 0;
 
     #ifdef USES_TEMP
+        void ShowTemp();
+
+        int currentTemp;
+        unsigned long idleTempStamp = 0;
         bool showingTemp = false;
         // storage of temperature string
         char tempString[5];

--- a/OpenFIREmain/OpenFIREdisplay.h
+++ b/OpenFIREmain/OpenFIREdisplay.h
@@ -12,6 +12,8 @@
 #include <stdint.h>
 #include <Adafruit_SSD1306.h>
 
+#include "OpenFIREDefines.h"
+
 #define SCREEN_WIDTH 128
 #define SCREEN_HEIGHT 64
 
@@ -111,11 +113,18 @@ private:
     uint8_t currentAmmo;
     uint8_t currentLife;
 
-    // timestamps, in case we need them for periodic tasks in IdleOps()
+    #define OLED_IDLEUPD_INTERVAL 5000
+
+    // timestamps for periodic tasks in IdleOps()
     unsigned long ammoTimestamp = 0;
     unsigned long lifeTimestamp = 0;
     unsigned long idleTimeStamp = 0;
 
+    #ifdef USES_TEMP
+        bool showingTemp = false;
+        // storage of temperature string
+        char tempString[5];
+    #endif // USES_TEMP
 
     #define NUMBER_GLYPH_WIDTH 21
     #define NUMBER_GLYPH_HEIGHT 36

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -738,33 +738,31 @@ void ExecRunMode()
             FW_Common::irPosUpdateTick = 0;
             FW_Common::GetPosition();
         }
-
-        #ifdef MAMEHOOKER
-            #ifdef USES_DISPLAY
-                // For some reason, solenoid feedback is hella wonky when ammo updates are performed on the second core,
-                // so just do it here using the signal sent by it.
-                if(OF_Serial::serialDisplayChange) {
-                    if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Ammo) {
-                        FW_Common::OLED.PrintAmmo(OF_Serial::serialAmmoCount);
-                    } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Life && FW_Common::OLED.lifeBar) {
-                        FW_Common::OLED.PrintLife(FW_Common::dispLifePercentage);
-                    } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Life) {
-                        FW_Common::OLED.PrintLife(OF_Serial::serialLifeCount);
-                    } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Both && FW_Common::OLED.lifeBar) {
-                        FW_Common::OLED.PrintAmmo(OF_Serial::serialAmmoCount);
-                        FW_Common::OLED.PrintLife(FW_Common::dispLifePercentage);
-                    } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Both) {
-                        FW_Common::OLED.PrintAmmo(OF_Serial::serialAmmoCount);
-                        FW_Common::OLED.PrintLife(OF_Serial::serialLifeCount);
-                    }
-
-                    OF_Serial::serialDisplayChange = false;
-                }
-            #endif // USES_DISPLAY
-        #endif // MAMEHOOKER
-
         #ifdef USES_DISPLAY
-            FW_Common::OLED.IdleOps();
+            else {
+                FW_Common::OLED.IdleOps();
+                #ifdef MAMEHOOKER
+                    // For some reason, solenoid feedback is hella wonky when ammo updates are performed on the second core,
+                    // so just do it here using the signal sent by it.
+                    if(OF_Serial::serialDisplayChange) {
+                        if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Ammo) {
+                            FW_Common::OLED.PrintAmmo(OF_Serial::serialAmmoCount);
+                        } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Life && FW_Common::OLED.lifeBar) {
+                            FW_Common::OLED.PrintLife(FW_Common::dispLifePercentage);
+                        } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Life) {
+                            FW_Common::OLED.PrintLife(OF_Serial::serialLifeCount);
+                        } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Both && FW_Common::OLED.lifeBar) {
+                            FW_Common::OLED.PrintAmmo(OF_Serial::serialAmmoCount);
+                            FW_Common::OLED.PrintLife(FW_Common::dispLifePercentage);
+                        } else if(FW_Common::OLED.serialDisplayType == ExtDisplay::ScreenSerial_Both) {
+                            FW_Common::OLED.PrintAmmo(OF_Serial::serialAmmoCount);
+                            FW_Common::OLED.PrintLife(OF_Serial::serialLifeCount);
+                        }
+
+                        OF_Serial::serialDisplayChange = false;
+                    }
+                #endif // MAMEHOOKER
+            }
         #endif // USES_DISPLAY
 
         // If using RP2040, we offload the button processing to the second core.

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -289,7 +289,7 @@ void loop1()
                 } else {   // Or if we haven't pressed the trigger,
                     TriggerNotFireSimple();                             // Release button inputs.
                 }
-                OF_Serial::SerialHandling();                                       // Process the force feedback.
+                OF_Serial::SerialHandling();                            // Process the force feedback.
             }
         #else
             if(bitRead(FW_Common::buttons.debounced, 0)) {   // Check if we pressed the Trigger this run.
@@ -305,6 +305,11 @@ void loop1()
                 lastAnalogPoll = millis();
             }
         #endif // USES_ANALOG
+
+        #ifdef USES_TEMP
+            if(OF_Prefs::pins[OF_Const::tempPin] > -1)
+                OF_FFB::TemperatureUpdate();
+        #endif // USES_TEMP
         
         if(FW_Common::buttons.pressedReleased == FW_Const::EscapeKeyBtnMask)
             SendEscapeKey();
@@ -758,6 +763,10 @@ void ExecRunMode()
             #endif // USES_DISPLAY
         #endif // MAMEHOOKER
 
+        #ifdef USES_DISPLAY
+            FW_Common::OLED.IdleOps();
+        #endif // USES_DISPLAY
+
         // If using RP2040, we offload the button processing to the second core.
         #if !defined(ARDUINO_ARCH_RP2040) || !defined(DUAL_CORE)
 
@@ -767,6 +776,11 @@ void ExecRunMode()
                 lastAnalogPoll = millis();
             }
         #endif // USES_ANALOG
+
+        #ifdef USES_TEMP
+            if(OF_Prefs::pins[OF_Const::tempPin] > -1)
+                OF_FFB::TemperatureUpdate();
+        #endif // USES_TEMP
 
         if(FW_Common::buttons.pressedReleased == FW_Const::EscapeKeyBtnMask)
             SendEscapeKey();
@@ -929,31 +943,37 @@ void ExecGunModeDocked()
                     }
             }
 
-            OF_FFB::TemperatureUpdate();
-            unsigned long currentMillis = millis();
-            if(currentMillis - tempChecked >= 1000) {
-                if(OF_Prefs::pins[OF_Const::tempPin] >= 0) {
-                    const char buf[] = {OF_Const::sTemperatureUpd, (uint8_t)OF_FFB::temperatureCurrent};
-                    Serial.write(buf, 2);
-                }
+            #ifdef USES_TEMP
+                if(OF_Prefs::pins[OF_Const::tempPin] > -1)
+                    OF_FFB::TemperatureUpdate();
 
-                tempChecked = currentMillis;
-            }
+                unsigned long currentMillis = millis();
+                if(currentMillis - tempChecked >= 1000) {
+                    if(OF_Prefs::pins[OF_Const::tempPin] >= 0) {
+                        const char buf[] = {OF_Const::sTemperatureUpd, (uint8_t)OF_FFB::temperatureCurrent};
+                        Serial.write(buf, 2);
+                    }
+
+                    tempChecked = currentMillis;
+                }
+            #endif // USES_TEMP
             
-            if(FW_Common::analogIsValid) {
-                if(currentMillis - aStickChecked >= 100) {
-                    aStickChecked = currentMillis;
+            #ifdef USES_ANALOG
+                if(FW_Common::analogIsValid) {
+                    if(currentMillis - aStickChecked >= 100) {
+                        aStickChecked = currentMillis;
 
-                    // TODO: replace with just sending coords normally instead of an approximated cardinal.
-                    uint16_t analogValueX = analogRead(OF_Prefs::pins[OF_Const::analogX]);
-                    uint16_t analogValueY = analogRead(OF_Prefs::pins[OF_Const::analogY]);
-                    
-                    char buf[5] = {OF_Const::sAnalogPosUpd};
-                    memcpy(&buf[1], (uint8_t*)&analogValueX, sizeof(uint16_t));
-                    memcpy(&buf[3], (uint8_t*)&analogValueY, sizeof(uint16_t));
-                    Serial.write(buf, sizeof(buf));
+                        // TODO: replace with just sending coords normally instead of an approximated cardinal.
+                        uint16_t analogValueX = analogRead(OF_Prefs::pins[OF_Const::analogX]);
+                        uint16_t analogValueY = analogRead(OF_Prefs::pins[OF_Const::analogY]);
+                        
+                        char buf[5] = {OF_Const::sAnalogPosUpd};
+                        memcpy(&buf[1], (uint8_t*)&analogValueX, sizeof(uint16_t));
+                        memcpy(&buf[3], (uint8_t*)&analogValueY, sizeof(uint16_t));
+                        Serial.write(buf, sizeof(buf));
+                    }
                 }
-            }
+            #endif // USES_ANALOG
         }
 
         if(FW_Common::gunMode != FW_Const::GunMode_Docked)

--- a/OpenFIREmain/OpenFIREprefs.h
+++ b/OpenFIREmain/OpenFIREprefs.h
@@ -83,33 +83,35 @@ public:
     static inline uint currentProfile = 0;
 
     static inline bool toggles[OF_Const::boolTypesCount] = {
-        false,
-        true,
-        true,
-        false,
-        false,
-        false,
-        true,
-        false,
-        false,
-        false
+        false,          // custom pins
+        true,           // rumble
+        true,           // solenoid
+        false,          // autofire
+        false,          // simple pause menu
+        false,          // hold to pause
+        true,           // 4pin common anode
+        false,          // low buttons mode
+        false,          // rumble force-feedback mode
+        false,          // invert static pixels
     };
 
     static inline int8_t pins[OF_Const::boardInputsCount] = { -1 };
 
     static inline uint32_t settings[OF_Const::settingsTypesCount] = {
-        255,
-        150,
-        45,
-        30,
-        500,
-        3,
-        2500,
-        1,
-        0,
-        0xFF0000,
-        0x00FF00,
-        0x0000FF
+        255,            // rumble strength
+        150,            // rumble length
+        45,             // solenoid norm interv
+        30,             // solenoid fast interv
+        500,            // solenoid hold length
+        3,              // autofire factor
+        2500,           // hold-to-pause length
+        1,              // custom NeoPixel strand length
+        0,              // custom NeoPixel static count
+        0xFF0000,       // custom pixel color 1
+        0x00FF00,       // custom pixel color 2
+        0x0000FF,       // custom pixel color 3
+        35,             // temp warning
+        42,             // temp shutoff
     };
 
     static inline bool i2cPeriphs[OF_Const::i2cDevicesCount] = { false };


### PR DESCRIPTION
Solenoid temperature thresholds can now be customized by the user (at their own discression, ofc). Configuration of this feature depends on App ver TeamOpenFIRE/OpenFIRE-App#47. This closes #24.

Temperature is also polled in the main two modes where it's relevant (Run Mode and Docked Mode), not just whenever solenoid is being activated, and polling/averaging of current temperature is now spread out across four reads @ 250ms apart, so new values are updated once every second.

OLED idle operations are now a thing; its initial implem here switches the top ticker between showing current calibration profile and the current temperature reading (which updates every ~750ms so long as the temperature is showing). Currently this applies to all "normal run mode" screen modes - i.e. non-Hooked and either MameHooked modes. This closes #23 & #25.