### PR TITLE
Some Serial-related cleanups

### DIFF
--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -1103,6 +1103,7 @@ void OF_Serial::SerialProcessingDocked()
     {
         FW_Common::buttons.Unset();
         bool exit = false;
+        Serial.write(OF_Const::sCommitStart), Serial.flush();
         while(!exit) {
             if(Serial.available()) {
                 switch(Serial.read()) {

--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -1286,7 +1286,7 @@ void OF_Serial::SerialProcessingDocked()
 
     case OF_Const::sClearFlash:
         OF_Prefs::ResetPreferences();
-        Serial.println("Cleared! Please reset the board.");
+        rp2040.reboot();
         break;
     }
 }


### PR DESCRIPTION
Prevent race conditions when starting a commit with temp enabled by having the board respond once it's ready to receive commit requests, which the connected server needs to wait for.

Once a clear request is sent, immediately reboot afterwards.