### PR TITLE
Simplify solenoid settings to a global ON and a single autofire wait value

### DIFF
--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -27,21 +27,16 @@ void OF_FFB::FFBOnScreen()
                     solenoidFirstShot = false;
             }
         // Else, these below are all if we've been holding the trigger.
-        } else if(burstFiring) {  // If we're in a burst firing sequence,
-            BurstFire();                                // Process it.
-        } else if(OF_Prefs::toggles[OF_Const::autofire] &&  // Else, if we've been holding the trigger, is the autofire switch active?
-                  !burstFireActive) {                          // (WITHOUT burst firing enabled)
-            if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])) {              // Is the solenoid engaged?
-                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval]); // If so, immediately pass the autofire faster interval to solenoid method
-            } else {                                    // Or if it's not,
-                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval] * OF_Prefs::settings[OF_Const::autofireWaitFactor]); // We're holding it for longer.
-            }
+        } else if(burstFiring) { BurstFire();
+        } else if(OF_Prefs::toggles[OF_Const::autofire] && !burstFireActive) {
+            if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]))
+                 SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval]);
+            else SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval] * OF_Prefs::settings[OF_Const::autofireWaitFactor]);
         } else if(solenoidFirstShot) {                  // If we aren't in autofire mode, are we waiting for the initial shot timer still?
             if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])) {              // If so, are we still engaged? We need to let it go normally, but maintain the single shot flag.
                 currentMillis = millis();
-                if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidNormalInterval]) { // If we finally surpassed the wait threshold...
-                    digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);     // Let it go.
-                }
+                if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidNormalInterval])
+                    digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);
             } else {                                    // We're waiting on the extended wait before repeating in single shot mode.
                 currentMillis = millis();
                 if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidHoldLength]) { // If we finally surpassed the LONGER wait threshold...
@@ -50,38 +45,34 @@ void OF_FFB::FFBOnScreen()
                 }
             }
         } else if(!burstFireActive) {                   // if we don't have the single shot wait flag on (holding the trigger w/out autofire)
-            if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])) {              // Are we engaged right now?
-                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval]); // Turn it off with this timer.
-            } else {                                    // Or we're not engaged.
-                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval] * 2); // So hold it that way for twice the normal timer.
-            }
+            if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]))
+                 SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval]);
+            else SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval] < 1); // So hold it that way for twice the normal timer.
         }
     // only activate rumbleFF as a fallback if Solenoid is explicitly disabled
-    } else if(OF_Prefs::toggles[OF_Const::rumble] &&
-              OF_Prefs::toggles[OF_Const::rumbleFF] && !rumbleHappened && !triggerHeld) {
+    } else if(OF_Prefs::toggles[OF_Const::rumble] && OF_Prefs::toggles[OF_Const::rumbleFF] && !rumbleHappened && !triggerHeld)
         RumbleActivation();
-    }
-    if(OF_Prefs::toggles[OF_Const::rumble] &&  // Is rumble activated,
-       rumbleHappening && triggerHeld) {  // AND we're in a rumbling command WHILE the trigger's held?
+
+    if(OF_Prefs::toggles[OF_Const::rumble] && rumbleHappening && triggerHeld)
         RumbleActivation();                    // Continue processing the rumble command, to prevent infinite rumble while going from on-screen to off mid-command.
-    }
 }
 
 void OF_FFB::FFBOffScreen()
 {
-    if(OF_Prefs::toggles[OF_Const::rumble]) {  // Only activate if the rumble switch is enabled!
-        if(!OF_Prefs::toggles[OF_Const::rumbleFF] &&
-           !rumbleHappened && !triggerHeld) {  // Is this the first time we're rumbling AND only started pulling the trigger (to prevent starting a rumble w/ trigger hold)?
+    if(OF_Prefs::toggles[OF_Const::rumble]) {
+        // Is this the first time we're rumbling AND only started pulling the trigger (to prevent starting a rumble w/ trigger hold)?
+        if(!OF_Prefs::toggles[OF_Const::rumbleFF] && !rumbleHappened && !triggerHeld) {
             RumbleActivation();                        // Start a rumble command.
         } else if(rumbleHappening) {  // We are currently processing a rumble command.
             RumbleActivation();                        // Keep processing that command then.
         }  // Else, we rumbled already, so don't do anything to prevent infinite rumbling.
     }
-    if(burstFiring) {                                  // If we're in a burst firing sequence,
-        BurstFire();
-    } else if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]) && !burstFireActive) { // If the solenoid is engaged, since we're not shooting the screen, shut off the solenoid a'la an idle cycle
+
+    if(burstFiring) BurstFire();
+    else if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]) && !burstFireActive) { // If the solenoid is engaged, since we're not shooting the screen, shut off the solenoid a'la an idle cycle
         currentMillis = millis();                      // Calibrate current time
-        if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidFastInterval]) { // I guess if we're not firing, may as well use the fastest shutoff.
+        if(currentMillis - previousMillisSol >=
+           OF_Prefs::settings[OF_Const::solenoidFastInterval] > OF_Prefs::settings[OF_Const::solenoidNormalInterval] ? OF_Prefs::settings[OF_Const::solenoidFastInterval] : OF_Prefs::settings[OF_Const::solenoidNormalInterval]) {
             previousMillisSol = currentMillis;
             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);
         }
@@ -91,9 +82,8 @@ void OF_FFB::FFBOffScreen()
 void OF_FFB::FFBRelease()
 {
     if(OF_Prefs::toggles[OF_Const::solenoid]) {  // Has the solenoid remain engaged this cycle?
-        if(burstFiring) {    // Are we in a burst fire command?
-            BurstFire();                                    // Continue processing it.
-        } else if(!burstFireActive) { // Else, we're just processing a normal/rapid fire shot.
+        if(burstFiring) BurstFire();
+        else if(!burstFireActive) { // Else, we're just processing a normal/rapid fire shot.
             solenoidFirstShot = false;                      // Make sure this is unset to prevent "sticking" in single shot mode!
             currentMillis = millis();
             if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidFastInterval]) { // I guess if we're not firing, may as well use the fastest shutoff.

--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -2,17 +2,19 @@
  * @file OpenFIREFeedback.cpp
  * @brief Force feedback subsystems.
  *
- * @copyright That One Seong, 2024
+ * @copyright That One Seong, 2025
  * @copyright GNU Lesser General Public License
  */ 
 
 #include <Arduino.h>
+
 #include "OpenFIREFeedback.h"
 
 void OF_FFB::FFBOnScreen()
 {
     if(OF_Prefs::toggles[OF_Const::solenoid]) {                             // (Only activate when the solenoid switch is on!)
-        if(!triggerHeld) {  // If this is the first time we're firing,
+        // If this is the first time we're firing,
+        if(!triggerHeld) {
             if(burstFireActive && !burstFiring) {  // Are we in burst firing mode?
                 solenoidFirstShot = true;               // Set this so we use the instant solenoid fire path,
                 SolenoidActivation(0);                  // Engage it,
@@ -29,25 +31,18 @@ void OF_FFB::FFBOnScreen()
         // Else, these below are all if we've been holding the trigger.
         } else if(burstFiring) { BurstFire();
         } else if(OF_Prefs::toggles[OF_Const::autofire] && !burstFireActive) {
-            if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]))
-                 SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval]);
-            else SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval] * OF_Prefs::settings[OF_Const::autofireWaitFactor]);
+            SolenoidActivation(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]) ? OF_Prefs::settings[OF_Const::solenoidOnLength] : OF_Prefs::settings[OF_Const::solenoidOffLength] << autofireDoubleLengthWait);
         } else if(solenoidFirstShot) {                  // If we aren't in autofire mode, are we waiting for the initial shot timer still?
             if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])) {              // If so, are we still engaged? We need to let it go normally, but maintain the single shot flag.
                 currentMillis = millis();
-                if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidNormalInterval])
+                if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidOnLength])
                     digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);
-            } else {                                    // We're waiting on the extended wait before repeating in single shot mode.
-                currentMillis = millis();
-                if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidHoldLength]) { // If we finally surpassed the LONGER wait threshold...
-                    solenoidFirstShot = false;          // We're gonna turn this off so we don't have to pass through this check anymore.
-                    SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval]); // Process it now.
-                }
+            } else if(millis() - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidHoldLength]) { // We're waiting on the extended wait before repeating in single shot mode.
+                SolenoidActivation(0); // Process it now.
+                solenoidFirstShot = false;          // We're gonna turn this off so we don't have to pass through this check anymore.
             }
         } else if(!burstFireActive) {                   // if we don't have the single shot wait flag on (holding the trigger w/out autofire)
-            if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]))
-                 SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval]);
-            else SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidNormalInterval] < 1); // So hold it that way for twice the normal timer.
+            SolenoidActivation(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]) ? OF_Prefs::settings[OF_Const::solenoidOnLength] : OF_Prefs::settings[OF_Const::solenoidOffLength]);
         }
     // only activate rumbleFF as a fallback if Solenoid is explicitly disabled
     } else if(OF_Prefs::toggles[OF_Const::rumble] && OF_Prefs::toggles[OF_Const::rumbleFF] && !rumbleHappened && !triggerHeld)
@@ -70,23 +65,18 @@ void OF_FFB::FFBOffScreen()
 
     if(burstFiring) BurstFire();
     else if(digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]) && !burstFireActive) { // If the solenoid is engaged, since we're not shooting the screen, shut off the solenoid a'la an idle cycle
-        currentMillis = millis();                      // Calibrate current time
-        if(currentMillis - previousMillisSol >=
-           OF_Prefs::settings[OF_Const::solenoidFastInterval] > OF_Prefs::settings[OF_Const::solenoidNormalInterval] ? OF_Prefs::settings[OF_Const::solenoidFastInterval] : OF_Prefs::settings[OF_Const::solenoidNormalInterval]) {
-            previousMillisSol = currentMillis;
-            digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);
-        }
+        SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidOnLength]);
     }
 }
 
 void OF_FFB::FFBRelease()
 {
-    if(OF_Prefs::toggles[OF_Const::solenoid]) {  // Has the solenoid remain engaged this cycle?
+    if(OF_Prefs::toggles[OF_Const::solenoid]) {
         if(burstFiring) BurstFire();
-        else if(!burstFireActive) { // Else, we're just processing a normal/rapid fire shot.
+        else if(!burstFireActive && digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])) {
             solenoidFirstShot = false;                      // Make sure this is unset to prevent "sticking" in single shot mode!
             currentMillis = millis();
-            if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidFastInterval]) { // I guess if we're not firing, may as well use the fastest shutoff.
+            if(currentMillis - previousMillisSol >= OF_Prefs::settings[OF_Const::solenoidOnLength]) { // I guess if we're not firing, may as well use the fastest shutoff.
                 previousMillisSol = currentMillis;
                 digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);             // Make sure to turn it off.
             }
@@ -127,7 +117,7 @@ void OF_FFB::SolenoidActivation(const int &solenoidFinalInterval)
                             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], !digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])); // Flip, flop.
                         }
                     } else { // The solenoid's probably off, not on right now. So that means we should wait a bit longer to fire again.
-                        if(currentMillis - previousMillisSol >= (OF_Prefs::settings[OF_Const::solenoidFastInterval] << 2)) { // We're keeping it low for a bit longer, to keep temps stable. Try to give it a bit of time to cool down before we go again.
+                        if(currentMillis - previousMillisSol >= (OF_Prefs::settings[OF_Const::solenoidOffLength] << autofireDoubleLengthWait ? 3 : 2)) { // We're keeping it low for a bit longer, to keep temps stable. Try to give it a bit of time to cool down before we go again.
                             previousMillisSol = currentMillis;
                             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], !digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]));
                         }
@@ -192,7 +182,7 @@ void OF_FFB::RumbleActivation()
         currentMillis = millis();                                 // Calibrate a timer to set how long we've been rumbling.
         if(OF_Prefs::toggles[OF_Const::rumbleFF]) {
             if(!OF_Prefs::toggles[OF_Const::autofire]) {       // We only want to use the rumble timer if Autofire is not active. Otherwise, keep it going
-                if(currentMillis - previousMillisRumble >= OF_Prefs::settings[OF_Const::rumbleInterval] / 2) { // If we've been waiting long enough for this whole rumble command,
+                if(currentMillis - previousMillisRumble >= (OF_Prefs::settings[OF_Const::rumbleInterval] >> 1)) { // If we've been waiting long enough for this whole rumble command,
                     digitalWrite(OF_Prefs::pins[OF_Const::rumblePin], LOW);                         // Make sure the rumble is OFF.
                     rumbleHappening = false;                              // This rumble command is done now.
                     rumbleHappened = true;                                // And just to make sure, to prevent holding == repeat rumble commands.
@@ -221,10 +211,10 @@ void OF_FFB::BurstFire()
                 burstFireCount++;                                 // Increment the counter.
             }
             if(!digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])) {  // Now, is the solenoid NOT on right now?
-                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval] * 2);     // Hold it off a bit longer,
+                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidOffLength] << autofireDoubleLengthWait ? 1 : 0);     // Hold it off a bit longer,
             } else {                         // or if it IS on,
                 burstFireCountLast = burstFireCount;              // sync the counters since we completed one bullet cycle,
-                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidFastInterval]);         // And start trying to activate the dingus.
+                SolenoidActivation(OF_Prefs::settings[OF_Const::solenoidOnLength]);         // And start trying to activate the dingus.
             }
         #endif // USES_SOLENOID
         return;

--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -116,8 +116,8 @@ void OF_FFB::SolenoidActivation(const int &solenoidFinalInterval)
                             previousMillisSol = currentMillis;
                             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], !digitalRead(OF_Prefs::pins[OF_Const::solenoidPin])); // Flip, flop.
                         }
-                    } else { // The solenoid's probably off, not on right now. So that means we should wait a bit longer to fire again.
-                        if(currentMillis - previousMillisSol >= (OF_Prefs::settings[OF_Const::solenoidOffLength] << autofireDoubleLengthWait ? 3 : 2)) { // We're keeping it low for a bit longer, to keep temps stable. Try to give it a bit of time to cool down before we go again.
+                    } else { // The solenoid's probably off right now, so that means we should wait a bit longer to fire again.
+                        if(currentMillis - previousMillisSol >= (OF_Prefs::settings[OF_Const::solenoidOffLength] << 2)) { // We're keeping it low for a bit longer, to keep temps stable. Try to give it a bit of time to cool down before we go again.
                             previousMillisSol = currentMillis;
                             digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], !digitalRead(OF_Prefs::pins[OF_Const::solenoidPin]));
                         }

--- a/OpenFIREmain/OpenFIREFeedback.h
+++ b/OpenFIREmain/OpenFIREFeedback.h
@@ -43,6 +43,7 @@ public:
     // For autofire:
     static inline bool triggerHeld = false;                  // Trigger SHOULDN'T be being pulled by default, right?
     static inline bool burstFireActive = false;
+    static inline bool autofireDoubleLengthWait = false;
 
     // Current temperature as read from TMP36, in (approximate) Celsius
     static inline uint temperatureCurrent;

--- a/OpenFIREmain/OpenFIREconstant.h
+++ b/OpenFIREmain/OpenFIREconstant.h
@@ -115,9 +115,6 @@ public:
     // button combination to toggle offscreen button mode in software:
     static inline constexpr uint32_t OffscreenButtonToggleBtnMask = BtnMask_Reload | BtnMask_A;
 
-    // button combination to toggle offscreen button mode in software:
-    static inline constexpr uint32_t AutofireSpeedToggleBtnMask = BtnMask_Reload | BtnMask_B;
-
     // button combination to toggle rumble in software:
     static inline constexpr uint32_t RumbleToggleBtnMask = BtnMask_Left;
 

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -594,8 +594,6 @@ void loop()
                 FW_Common::SavePreferences();
             } else if(FW_Common::buttons.pressedReleased == FW_Const::OffscreenButtonToggleBtnMask) {
                 OffscreenToggle();
-            } else if(FW_Common::buttons.pressedReleased == FW_Const::AutofireSpeedToggleBtnMask) {
-                AutofireSpeedToggle();
             #ifdef USES_RUMBLE
                 } else if(FW_Common::buttons.pressedReleased == FW_Const::RumbleToggleBtnMask && OF_Prefs::pins[OF_Const::rumbleSwitch] >= 0) {
                     RumbleToggle();
@@ -1400,42 +1398,6 @@ void OffscreenToggle()
 
         return;
     }
-}
-
-// Pause mode autofire factor toggle widget
-// Does a test fire demonstrating the autofire speed being toggled
-void AutofireSpeedToggle()
-{
-    switch (OF_Prefs::settings[OF_Const::autofireWaitFactor]) {
-        case 2:
-            OF_Prefs::settings[OF_Const::autofireWaitFactor] = 3;
-            Serial.println("Autofire speed level 2.");
-            break;
-        case 3:
-            OF_Prefs::settings[OF_Const::autofireWaitFactor] = 4;
-            Serial.println("Autofire speed level 3.");
-            break;
-        case 4:
-            OF_Prefs::settings[OF_Const::autofireWaitFactor] = 2;
-            Serial.println("Autofire speed level 1.");
-            break;
-    }
-    #ifdef LED_ENABLE
-        OF_RGB::SetLedPackedColor(WikiColor::Magenta);                    // Set a color,
-    #endif // LED_ENABLE
-
-    #ifdef USES_SOLENOID
-        for(uint i = 0; i < 5; ++i) {                             // And demonstrate the new autofire factor five times!
-            digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], HIGH);
-            delay(OF_Prefs::settings[OF_Const::solenoidFastInterval]);
-            digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);
-            delay(OF_Prefs::settings[OF_Const::solenoidFastInterval] * OF_Prefs::settings[OF_Const::autofireWaitFactor]);
-        }
-    #endif // USES_SOLENOID
-
-    #ifdef LED_ENABLE
-        OF_RGB::SetLedPackedColor(OF_Prefs::profiles[OF_Prefs::currentProfile].color);    // And reset the LED back to pause mode color
-    #endif // LED_ENABLE
 }
 
 /*

--- a/OpenFIREmain/OpenFIREprefs.h
+++ b/OpenFIREmain/OpenFIREprefs.h
@@ -100,10 +100,9 @@ public:
     static inline uint32_t settings[OF_Const::settingsTypesCount] = {
         255,            // rumble strength
         150,            // rumble length
-        45,             // solenoid norm interv
-        30,             // solenoid fast interv
+        45,             // solenoid on length
+        30,             // solenoid off length
         500,            // solenoid hold length
-        3,              // autofire factor
         2500,           // hold-to-pause length
         1,              // custom NeoPixel strand length
         0,              // custom NeoPixel static count

--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -321,13 +321,7 @@ void OF_Serial::SerialProcessing()
           switch(serialInput) {
               // Set Autofire Interval Length
               case 'I':
-                serialInput = Serial.read();
-                if(serialInput >= '2' && serialInput <= '4') {
-                    uint8_t afSetting = serialInput - '0';
-                    OF_Prefs::settings[OF_Const::autofireWaitFactor] = afSetting;
-                    Serial.print("Autofire speed level ");
-                    Serial.println(afSetting);
-                } else Serial.println("SERIALREAD: No valid interval set! (Expected 2 to 4)");
+                OF_FFB::autofireDoubleLengthWait = Serial.read();
                 break;
               // Remap player numbers
               case 'R':
@@ -710,7 +704,7 @@ void OF_Serial::SerialHandling()
                               else serialSolPulsesLast++, serialSolPulsesLastUpdate = millis();  // Timestamp our last pulse event.
                           }
                       // current settings hold length
-                      } else if(millis() - serialSolPulsesLastUpdate >= OF_Prefs::settings[OF_Const::solenoidNormalInterval]) {
+                      } else if(millis() - serialSolPulsesLastUpdate >= OF_Prefs::settings[OF_Const::solenoidOnLength]) {
                           digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);  // Start pulsing it off.
                           if(serialSolPulsesLast >= serialSolPulses)
                               serialQueue[SerialQueue_SolPulse] = false;
@@ -725,7 +719,7 @@ void OF_Serial::SerialHandling()
                           }
                       // current settings pause length
                       } else if(millis() - serialSolPulsesLastUpdate >=
-                                OF_Prefs::settings[OF_Const::solenoidFastInterval] * OF_Prefs::settings[OF_Const::autofireWaitFactor]) {
+                                OF_Prefs::settings[OF_Const::solenoidOffLength] << OF_FFB::autofireDoubleLengthWait ? 1 : 0) {
                           digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], HIGH); // Start pulsing it on.
                           serialSolPulsesLastUpdate = millis();          // Timestamp our last pulse event.
                       }
@@ -1076,7 +1070,7 @@ void OF_Serial::SerialProcessingDocked()
     #ifdef USES_SOLENOID
     case OF_Const::sTestSolenoid:
         digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], HIGH);
-        delay(OF_Prefs::settings[OF_Const::solenoidNormalInterval]);
+        delay(OF_Prefs::settings[OF_Const::solenoidOnLength]);
         digitalWrite(OF_Prefs::pins[OF_Const::solenoidPin], LOW);
         break;
     #endif // USES_SOLENOID


### PR DESCRIPTION
In retrospect, the way I made Solenoid Force Feedback work originally was weird;
 - It assumed that the "Fast" interval was actually always faster when letting the trigger off early on a first shot.
 - Autofire used an overcomplicated "Fast Interval * Multiplier" system, which required float computation
 - Users complained about wondering how it worked, so very few people actually made use of the different types of "interval" values just to be able to toggle a custom AF wait factor using a solenoid command that isn't even a standard.

With this PR, we have simplified the setup to just two values:
 - Solenoid ON Length determines how long the solenoid should be engaged
 - Solenoid OFF Length is how long the solenoid should remain off between autofire cycles, no mult needed.

Since it was useful before, the `XI1` command will now enable a runtime "autofire double length" toggle, which effectively doubles Solenoid OFF Length when enabled. `XI0` will disable this flag.