### PR TITLE
USB polling overhaul, cleanup

### DIFF
--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -326,6 +326,7 @@ void FW_Common::ExecCalMode(const bool &fromDesktop)
 
     // Force center mouse to center
     AbsMouse5.move(32768/2, 32768/2);
+    AbsMouse5.report();
 
     // Initialize current mouse positions (local variables)
     int32_t mouseCurrentX = 32768 / 2;
@@ -365,6 +366,7 @@ void FW_Common::ExecCalMode(const bool &fromDesktop)
                 mouseCurrentY += (deltaY > 0) ? stepY : -stepY;
 
             AbsMouse5.move(mouseCurrentX, mouseCurrentY);
+            AbsMouse5.report();
 
             if (mouseCurrentX == mouseTargetX && mouseCurrentY == mouseTargetY) {
                 mouseMoving = false;
@@ -404,8 +406,10 @@ void FW_Common::ExecCalMode(const bool &fromDesktop)
             switch(calStage) {
                 case FW_Const::Cali_Init:
                     // Initial state, nothing to do (but center cursor for desktop use)
-                    if(fromDesktop)
+                    if(fromDesktop) {
                         AbsMouse5.move(32768/2, 32768/2);
+                        AbsMouse5.report();
+                    }
                     break;
                 case FW_Const::Cali_Top:
                     // Reset Offsets
@@ -587,6 +591,7 @@ void FW_Common::ExecCalMode(const bool &fromDesktop)
                             OF_Prefs::profiles[OF_Prefs::currentProfile].adjY = 384 << 2;
                             SetMode(FW_Const::GunMode_Calibration);
                             AbsMouse5.move(32768/2, 32768/2);
+                            AbsMouse5.report();
                         // Press C/Home to exit without committing new calibration values
                         } else if(buttons.pressedReleased & FW_Const::ExitPauseModeBtnMask && !justBooted) {
                             Serial.printf("%c%c", OF_Const::sCaliStageUpd, FW_Const::Cali_Verify+1);
@@ -736,6 +741,7 @@ void FW_Common::GetPosition()
 
             } else if(gunMode == FW_Const::GunMode_Verification) {
                 AbsMouse5.move(conMoveX, conMoveY);
+                AbsMouse5.report();
             } else {
                 if(millis() - testLastStamp > 50) {
                     testLastStamp = millis();

--- a/OpenFIREmain/OpenFIREmain.h
+++ b/OpenFIREmain/OpenFIREmain.h
@@ -38,6 +38,8 @@
   void rp2040pwmIrq(void);
 #endif
 
+#define POLL_RATE 1
+
 // TinyUSB devices interface object that's initialized in MainCoreSetup
 TinyUSBDevices_ TUSBDeviceSetup;
 
@@ -50,6 +52,9 @@ bool pauseModeSelectingProfile = false;
 unsigned long pauseHoldStartstamp;
 bool pauseHoldStarted = false;
 bool pauseExitHoldStarted = false;
+
+// Timestamp of last USB packet update.
+unsigned long lastUSBpoll = 0;
 
 uint32_t fifoData = 0;
 

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -284,7 +284,7 @@ void loop1()
             TriggerFire();                                  // Handle button events and feedback ourselves.
         else TriggerNotFire();                              // Releasing button inputs and sending stop signals to feedback devices.
 
-        if(millis() - lastUSBpoll > POLL_RATE) {
+        if(millis() - lastUSBpoll >= POLL_RATE) {
             #ifdef USES_ANALOG
                 if(FW_Common::analogIsValid) AnalogStickPoll();
             #endif // USES_ANALOG
@@ -725,7 +725,7 @@ void ExecRunMode()
             TriggerFire();                                  // Handle button events and feedback ourselves.
         else TriggerNotFire();                              // Releasing button inputs and sending stop signals to feedback devices.
 
-        if(millis() - lastUSBpoll > POLL_RATE) {
+        if(millis() - lastUSBpoll >= POLL_RATE) {
             #ifdef USES_ANALOG
                 if(FW_Common::analogIsValid) AnalogStickPoll();
             #endif // USES_ANALOG

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -1035,8 +1035,11 @@ void AnalogStickPoll()
 void SendEscapeKey()
 {
     Keyboard.press(KEY_ESC);
+    Keyboard.report();
     delay(20);  // wait a bit so it registers on the PC.
     Keyboard.release(KEY_ESC);
+    Keyboard.report();
+    lastUSBpoll = millis();
 }
 
 // Simple Pause Menu scrolling function

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -101,7 +101,7 @@ void setup() {
         // is VBUS (USB voltage) detected?
         if(digitalRead(34)) {
             // If so, we're connected via USB, so initializing the USB devices chunk.
-            TUSBDeviceSetup.begin(1);
+            TUSBDeviceSetup.begin(POLL_RATE);
             // wait until device mounted
             while(!USBDevice.mounted()) { yield(); }
             Serial.begin(9600);
@@ -114,7 +114,7 @@ void setup() {
         }
         #else
         // Initializing the USB devices chunk.
-        TUSBDeviceSetup.begin(1);
+        TUSBDeviceSetup.begin(POLL_RATE);
         // wait until device mounted
         while(!USBDevice.mounted()) { yield(); }
         Serial.begin(9600);   // 9600 = 1ms data transfer rates, default for MAMEHOOKER COM devices.
@@ -140,8 +140,6 @@ void setup() {
     #ifdef LED_ENABLE
         OF_RGB::LedInit();
     #endif // LED_ENABLE
-    
-    AbsMouse5.init(true);
 
     // IR camera maxes out motion detection at ~300Hz, and millis() isn't good enough
     startIrCamTimer(209);
@@ -270,15 +268,14 @@ void setup1()
 // currently handles all button & serial processing when Core 0 is in ExecRunMode()
 void loop1()
 {
-    #ifdef USES_ANALOG
-        unsigned long lastAnalogPoll = millis();
-    #endif // USES_ANALOG
-
     while(FW_Common::gunMode == FW_Const::GunMode_Run) {
         // All buttons' outputs except for the trigger are processed here.
         FW_Common::buttons.Poll(0);
 
-        if(Serial.available()) OF_Serial::SerialProcessing();
+        #ifdef USES_TEMP
+            if(OF_Prefs::pins[OF_Const::tempPin] > -1)
+                OF_FFB::TemperatureUpdate();
+        #endif // USES_TEMP
 
         // For processing the trigger specifically.
         // (FW_Common::buttons.debounced is a binary variable intended to be read 1 bit at a time,
@@ -287,21 +284,19 @@ void loop1()
             TriggerFire();                                  // Handle button events and feedback ourselves.
         else TriggerNotFire();                              // Releasing button inputs and sending stop signals to feedback devices.
 
+        if(millis() - lastUSBpoll > POLL_RATE) {
+            #ifdef USES_ANALOG
+                if(FW_Common::analogIsValid) AnalogStickPoll();
+            #endif // USES_ANALOG
+            lastUSBpoll = millis();
+            FW_Common::buttons.SendReports();
+        }
+
+        if(Serial.available()) OF_Serial::SerialProcessing();
+
         #ifdef MAMEHOOKER
             if(OF_Serial::serialMode) OF_Serial::SerialHandling();                                   // Process the force feedback from the current queue.
         #endif // MAMEHOOKER
-
-        #ifdef USES_ANALOG
-            if(FW_Common::analogIsValid && millis() - lastAnalogPoll > 1) {
-                AnalogStickPoll();
-                lastAnalogPoll = millis();
-            }
-        #endif // USES_ANALOG
-
-        #ifdef USES_TEMP
-            if(OF_Prefs::pins[OF_Const::tempPin] > -1)
-                OF_FFB::TemperatureUpdate();
-        #endif // USES_TEMP
         
         if(FW_Common::buttons.pressedReleased == FW_Const::EscapeKeyBtnMask)
             SendEscapeKey();
@@ -647,10 +642,6 @@ void ExecRunMode()
         FW_Common::justBooted = false;
     }
 
-    #ifdef USES_ANALOG
-        unsigned long lastAnalogPoll = millis();
-    #endif // USES_ANALOG
-
     for(;;) {
         // Setting the state of our toggles, if used.
         // Only sets these values if the switches are mapped to valid pins.
@@ -686,26 +677,6 @@ void ExecRunMode()
                 OF_Prefs::toggles[OF_Const::autofire] = !digitalRead(OF_Prefs::pins[OF_Const::autofireSwitch]);
         #endif // USES_SWITCHES
 
-        // If we're on RP2040, we offload the button polling to the second core.
-        #if !defined(ARDUINO_ARCH_RP2040) || !defined(DUAL_CORE)
-        FW_Common::buttons.Poll(0);
-
-        // Run through serial receive buffer once this run, if it has contents.
-        if(Serial.available())
-            OF_Serial::SerialProcessing();
-
-        // For processing the trigger specifically.
-        // (FW_Common::buttons.debounced is a binary variable intended to be read 1 bit at a time,
-        // with the 0'th point == rightmost == decimal 1 == trigger, 3 = start, 4 = select)
-        if(bitRead(FW_Common::buttons.debounced, FW_Const::BtnIdx_Trigger))   // Check if we pressed the Trigger this run.
-            TriggerFire();                                  // Handle button events and feedback ourselves.
-        else TriggerNotFire();                              // Releasing button inputs and sending stop signals to feedback devices.
-
-        #ifdef MAMEHOOKER
-            if(OF_Serial::serialMode) OF_Serial::SerialHandling();                                   // Process the force feedback from the current queue.
-        #endif // MAMEHOOKER
-        #endif // DUAL_CORE
-
         if(FW_Common::irPosUpdateTick) {
             FW_Common::irPosUpdateTick = 0;
             FW_Common::GetPosition();
@@ -740,17 +711,34 @@ void ExecRunMode()
         // If using RP2040, we offload the button processing to the second core.
         #if !defined(ARDUINO_ARCH_RP2040) || !defined(DUAL_CORE)
 
-        #ifdef USES_ANALOG
-            if(FW_Common::analogIsValid && (millis() - lastAnalogPoll > 1)) {
-                AnalogStickPoll();
-                lastAnalogPoll = millis();
-            }
-        #endif // USES_ANALOG
-
         #ifdef USES_TEMP
             if(OF_Prefs::pins[OF_Const::tempPin] > -1)
                 OF_FFB::TemperatureUpdate();
         #endif // USES_TEMP
+
+        FW_Common::buttons.Poll(0);
+
+        // For processing the trigger specifically.
+        // (FW_Common::buttons.debounced is a binary variable intended to be read 1 bit at a time,
+        // with the 0'th point == rightmost == decimal 1 == trigger, 3 = start, 4 = select)
+        if(bitRead(FW_Common::buttons.debounced, FW_Const::BtnIdx_Trigger))   // Check if we pressed the Trigger this run.
+            TriggerFire();                                  // Handle button events and feedback ourselves.
+        else TriggerNotFire();                              // Releasing button inputs and sending stop signals to feedback devices.
+
+        if(millis() - lastUSBpoll > POLL_RATE) {
+            #ifdef USES_ANALOG
+                if(FW_Common::analogIsValid) AnalogStickPoll();
+            #endif // USES_ANALOG
+            lastUSBpoll = millis();
+            FW_Common::buttons.SendReports();
+        }
+
+        // Run through serial receive buffer once this run, if it has contents.
+        if(Serial.available()) OF_Serial::SerialProcessing();
+
+        #ifdef MAMEHOOKER
+            if(OF_Serial::serialMode) OF_Serial::SerialHandling();                                   // Process the force feedback from the current queue.
+        #endif // MAMEHOOKER
 
         if(FW_Common::buttons.pressedReleased == FW_Const::EscapeKeyBtnMask)
             SendEscapeKey();
@@ -773,11 +761,9 @@ void ExecRunMode()
                 if(t - pauseHoldStartstamp > OF_Prefs::settings[OF_Const::holdToPauseLength]) {
                     // MAKE SURE EVERYTHING IS DISENGAGED:
                     OF_FFB::FFBShutdown();
-		            Keyboard.releaseAll();
-                    AbsMouse5.releaseAll();
-                    Gamepad16.releaseAll();
                     FW_Common::offscreenBShot = false;
                     FW_Common::SetMode(FW_Const::GunMode_Pause);
+                    FW_Common::buttons.ReleaseAll();
                     FW_Common::buttons.ReportDisable();
                     return;
                 }
@@ -786,11 +772,9 @@ void ExecRunMode()
             if(FW_Common::buttons.pressedReleased == FW_Const::EnterPauseModeBtnMask || FW_Common::buttons.pressedReleased == FW_Const::BtnMask_Home) {
                 // MAKE SURE EVERYTHING IS DISENGAGED:
                 OF_FFB::FFBShutdown();
-		        Keyboard.releaseAll();
-                AbsMouse5.releaseAll();
-                Gamepad16.releaseAll();
                 FW_Common::offscreenBShot = false;
 		        FW_Common::SetMode(FW_Const::GunMode_Pause);
+                FW_Common::buttons.ReleaseAll();
                 FW_Common::buttons.ReportDisable();
                 return;
             }
@@ -799,9 +783,7 @@ void ExecRunMode()
         if(rp2040.fifo.pop_nb(&fifoData)) {
             FW_Common::SetMode((FW_Const::GunMode_e)fifoData);
             fifoData = 0;
-            Keyboard.releaseAll();
-            AbsMouse5.releaseAll();
-            Gamepad16.releaseAll();
+            FW_Common::buttons.ReleaseAll();
             // the value doesn't matter; all core1 is doing is waiting for any signal from the FIFO.
             rp2040.fifo.push(true);
             return;

--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -91,9 +91,7 @@ void OF_Serial::SerialProcessing()
                       #endif // USES_DISPLAY
                       break;
                 }
-                AbsMouse5.releaseAll();
-                Keyboard.releaseAll();
-                Gamepad16.releaseAll();
+                FW_Common::buttons.ReleaseAll();
                 #ifdef USES_DISPLAY
                     if(!serialMode && FW_Common::gunMode == FW_Const::GunMode_Run)
                         FW_Common::OLED.ScreenModeChange(ExtDisplay::Screen_Normal, FW_Common::buttons.analogOutput);
@@ -295,8 +293,7 @@ void OF_Serial::SerialProcessing()
                       serialSolCustomHoldLength = 0;
                       serialSolCustomPauseLength = 0;
                   #endif // USES_SOLENOID
-                  AbsMouse5.releaseAll();
-                  Keyboard.releaseAll();
+                  FW_Common::buttons.ReleaseAll();
                   // remap back to defaults, in case they were changed
                   FW_Common::UpdateBindings(OF_Prefs::toggles[OF_Const::lowButtonsMode]);
                   Serial.println("Received end serial pulse, releasing FF override.");

--- a/libraries/LightgunButtons/LightgunButtons.cpp
+++ b/libraries/LightgunButtons/LightgunButtons.cpp
@@ -40,7 +40,6 @@ LightgunButtons::LightgunButtons(Data_t _data, unsigned int _count) :
     debouncing(0),
     pressedReleased(0),
     padMask(0),
-    padMaskConv(0),
     interval(33),
     report(0),
     lastMillis(0),
@@ -83,7 +82,6 @@ void LightgunButtons::Unset()
     debouncing = 0;
     pressedReleased = 0;
     padMask = 0;
-    padMaskConv = 0;
     lastMillis = 0;
     lastRepeatMillis = 0;
     internalPressedReleased = 0;
@@ -183,8 +181,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.press(btn.reportCode3);
                                     } else {
                                         bitSet(padMask, btn.reportCode3-15);
-                                        PadMaskConvert();
-                                        Gamepad16.padUpdate(padMaskConv);
+                                        Gamepad16.padUpdate(PadMaskConvert());
                                     }
                                 }
                             } else if(offScreen) {
@@ -198,8 +195,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.press(btn.reportCode2);
                                     } else {
                                         bitSet(padMask, btn.reportCode2-15);
-                                        PadMaskConvert();
-                                        Gamepad16.padUpdate(padMaskConv);
+                                        Gamepad16.padUpdate(PadMaskConvert());
                                     }
                                 }
                             } else {
@@ -212,8 +208,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.press(btn.reportCode);
                                     } else {
                                         bitSet(padMask, btn.reportCode-15);
-                                        PadMaskConvert();
-                                        Gamepad16.padUpdate(padMaskConv);
+                                        Gamepad16.padUpdate(PadMaskConvert());
                                     }
                                 }
                             }
@@ -242,8 +237,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.release(btn.reportCode3);
                                     } else {
                                         bitClear(padMask, btn.reportCode3-15);
-                                        PadMaskConvert();
-                                        Gamepad16.padUpdate(padMaskConv);
+                                        Gamepad16.padUpdate(PadMaskConvert());
                                     }
                                 }
                             } else if(bitRead(internalOffscreenMask, i)) {
@@ -257,8 +251,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.release(btn.reportCode2);
                                     } else {
                                         bitClear(padMask, btn.reportCode2-15);
-                                        PadMaskConvert();
-                                        Gamepad16.padUpdate(padMaskConv);
+                                        Gamepad16.padUpdate(PadMaskConvert());
                                     }
                                 }
                             } else {
@@ -271,8 +264,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.release(btn.reportCode);
                                     } else {
                                         bitClear(padMask, btn.reportCode-15);
-                                        PadMaskConvert();
-                                        Gamepad16.padUpdate(padMaskConv);
+                                        Gamepad16.padUpdate(PadMaskConvert());
                                     }
                                 }
                             }
@@ -297,6 +289,30 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
     return pressed;
 }
 
+void LightgunButtons::SendReports(const bool &forceReportAll)
+{
+    if(TinyUSBDevices.newReport[ReportType_Mouse]) {
+        AbsMouse5.report();
+        if(!forceReportAll) return;
+    }
+    if(TinyUSBDevices.newReport[ReportType_Keyboard]) {
+        Keyboard.report();
+        if(!forceReportAll) return;
+    }
+    if(TinyUSBDevices.newReport[ReportType_Gamepad]) {
+        Gamepad16.report();
+        if(!forceReportAll) return;
+    }
+}
+
+void LightgunButtons::ReleaseAll()
+{
+    AbsMouse5.releaseAll();
+    Keyboard.releaseAll();
+    Gamepad16.releaseAll();
+    SendReports(true);
+}
+
 uint32_t LightgunButtons::Repeat()
 {
     unsigned long m = millis();
@@ -309,41 +325,41 @@ uint32_t LightgunButtons::Repeat()
     return repeat;
 }
 
-void LightgunButtons::PadMaskConvert()
+uint32_t LightgunButtons::PadMaskConvert()
 {
     switch(padMask) {
         case 1: // 0x00000001
-            padMaskConv = GAMEPAD_HAT_UP;
+            return GAMEPAD_HAT_UP;
             break;
         case 2: // 0x00000010
-            padMaskConv = GAMEPAD_HAT_DOWN;
+            return GAMEPAD_HAT_DOWN;
             break;
         case 4: // 0x00000100
-            padMaskConv = GAMEPAD_HAT_LEFT;
+            return GAMEPAD_HAT_LEFT;
             break;
         case 8: // 0x00001000
-            padMaskConv = GAMEPAD_HAT_RIGHT;
+            return GAMEPAD_HAT_RIGHT;
             break;
         case 5: // 0x00000101
-            padMaskConv = GAMEPAD_HAT_UP_LEFT;
+            return GAMEPAD_HAT_UP_LEFT;
             break;
         case 9: // 0x00001001
-            padMaskConv = GAMEPAD_HAT_UP_RIGHT;
+            return GAMEPAD_HAT_UP_RIGHT;
             break;
         case 6: // 0x00000110
-            padMaskConv = GAMEPAD_HAT_DOWN_LEFT;
+            return GAMEPAD_HAT_DOWN_LEFT;
             break;
         case 10: // 0x00001010
-            padMaskConv = GAMEPAD_HAT_DOWN_RIGHT;
+            return GAMEPAD_HAT_DOWN_RIGHT;
             break;
         case 3: // 0x00000011
-            padMaskConv = GAMEPAD_HAT_UP;
+            return GAMEPAD_HAT_UP;
             break;
         case 12: // 0x00001100
-            padMaskConv = GAMEPAD_HAT_LEFT;
+            return GAMEPAD_HAT_LEFT;
             break;
         default: // 0x00000000
-            padMaskConv = GAMEPAD_HAT_CENTERED;
+            return GAMEPAD_HAT_CENTERED;
             break;
     }
 }

--- a/libraries/LightgunButtons/LightgunButtons.h
+++ b/libraries/LightgunButtons/LightgunButtons.h
@@ -34,9 +34,9 @@ public:
     /// @brief Report type.
     enum ReportType_e {
         ReportType_Mouse = 0,
-        ReportType_Keyboard = 1,
-        ReportType_Internal = 2,
-        ReportType_Gamepad = 3
+        ReportType_Keyboard,
+        ReportType_Gamepad,
+        ReportType_Internal
     };
 
     /// @brief Descriptor.
@@ -73,6 +73,16 @@ public:
     /// @param[in] minTicks Minimum number of ticks for poll to update.
     /// @return The pressed value.
     uint32_t Poll(unsigned long minTicks = 0);
+
+    /// @brief Send reports queued up from Poll (and separate analog updates)
+    /// @param bool
+    ///        Whether to report on every channel sequentially
+    ///        Default behavior returns after the first flagged report channel
+    void SendReports(const bool &forceReportAll = false);
+
+    /// @brief Macro that signals all releaseAlls for each input device,
+    ///        and then force-sends each report sequentially.
+    void ReleaseAll();
 
     /// @brief Update the internal repeat value.
     /// @details Call after Poll() if the repeat value is required.
@@ -163,15 +173,12 @@ private:
 
     /// @brief Internal bit mask of directional buttons pressed.
     /// @details Only the four rightmost bits are used to track state of gamepad directional buttons pressed.
-    uint8_t padMask = 0x00000000;
-
-    /// @brief Bit mask of directional buttons pressed after conversion.
-    /// @details Converted from padMask before being passed over to TinyUSB_Devices' due to how HID POV works.
-    uint8_t padMaskConv = 0x00000000;
+    uint32_t padMask = 0;
 
     /// @brief Converts directional buttons bit mask from internal to HID format.
     /// @details Because the HID POV hat format makes no effing sense whatsoever.
-    void PadMaskConvert();
+    /// @returns Converted D-Pad mask
+    uint32_t PadMaskConvert();
 
     /// @brief Tracked buttons that are offscreen.
     uint32_t internalOffscreenMask;

--- a/libraries/TinyUSB_Devices/TinyUSB_Devices.cpp
+++ b/libraries/TinyUSB_Devices/TinyUSB_Devices.cpp
@@ -3,6 +3,7 @@
  * Chris Young's TinyUSB Mouse and Keyboard library (the Keyboard half, anyways),
  * which in itself uses pieces of Arduino's basic Keyboard library.
  */
+
 #ifdef USE_TINYUSB
   #include <Adafruit_TinyUSB.h>
 #elifdef CFG_TUSB_MCU
@@ -49,10 +50,7 @@ uint8_t desc_bt_report[] = {
 };
 #endif // ARDUINO_RASPBERRY_PI_PICO_W
 
-TinyUSBDevices_::TinyUSBDevices_(void) {
-}
-
-void TinyUSBDevices_::begin(byte polRate) {
+void TinyUSBDevices_::begin(int polRate) {
     usbHid.setPollInterval(polRate);
     usbHid.setReportDescriptor(desc_hid_report, sizeof(desc_hid_report));
     usbHid.begin();
@@ -110,7 +108,7 @@ static const uint8_t HID_REPORT_DESCRIPTOR5[] PROGMEM = {
 };
 #endif // _USING_HID
 
-AbsMouse5_::AbsMouse5_(uint8_t reportId) : _reportId(reportId), _buttons(0), _x(0), _y(0), _autoReport(true)
+AbsMouse5_::AbsMouse5_(uint8_t reportId) : _reportId(reportId), _buttons(0), _x(0), _y(0)
 {
 #if defined(_USING_HID)
 	static HIDSubDescriptor descriptorNode(HID_REPORT_DESCRIPTOR5, sizeof(HID_REPORT_DESCRIPTOR5));
@@ -118,36 +116,33 @@ AbsMouse5_::AbsMouse5_(uint8_t reportId) : _reportId(reportId), _buttons(0), _x(
 #endif // _USING_HID
 }
 
-void AbsMouse5_::init(bool autoReport)
-{
-	_autoReport = autoReport;
-}
-
 void AbsMouse5_::report(void)
 {
 	uint8_t buffer[5];
 	buffer[0] = _buttons;
+    // TODO: wouldn't two memcpys be faster here?
 	buffer[1] = _x & 0xFF;
 	buffer[2] = (_x >> 8) & 0xFF;
 	buffer[3] = _y & 0xFF;
 	buffer[4] = (_y >> 8) & 0xFF;
 
 #if defined(_USING_HID)
-	HID().SendReport(_reportId, buffer, 5);
+	HID().SendReport(_reportId, buffer, sizeof(buffer));
 #endif // _USING_HID
 #if defined(USE_TINYUSB)
     #if defined(ARDUINO_RASPBERRY_PI_PICO_W) && defined(ENABLE_CLASSIC)
-    if(TinyUSBDevices.onBattery) {
-      PicoBluetoothHID.send(HID_BT_MOUSE, buffer, 5);
-    } else {
+    if(TinyUSBDevices.onBattery)
+      PicoBluetoothHID.send(HID_BT_MOUSE, buffer, sizeof(buffer));
+    else {
       while(!usbHid.ready()) yield();
-      usbHid.sendReport(HID_RID_MOUSE, buffer, 5);
+      usbHid.sendReport(HID_RID_MOUSE, buffer, sizeof(buffer));
     }
     #else
     while(!usbHid.ready()) yield();
-    usbHid.sendReport(HID_RID_MOUSE, buffer, 5);
+    usbHid.sendReport(HID_RID_MOUSE, buffer, sizeof(buffer));
     #endif // ARDUINO_RASPBERRY_PI_PICO_W
 #endif // USE_TINYUSB
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportMouse] = false;
 }
 
 void AbsMouse5_::move(uint16_t x, uint16_t y)
@@ -155,28 +150,20 @@ void AbsMouse5_::move(uint16_t x, uint16_t y)
 	if(x != _x || y != _y) {
 		_x = x;
 		_y = y;
-		if(_autoReport) {
-			report();
-		}
+        TinyUSBDevices.newReport[TinyUSBDevices_::reportMouse] = true;
 	}
 }
 
 void AbsMouse5_::press(uint8_t button)
 {
 	_buttons |= button;
-
-	if(_autoReport) {
-		report();
-	}
+	TinyUSBDevices.newReport[TinyUSBDevices_::reportMouse] = true;
 }
 
 void AbsMouse5_::release(uint8_t button)
 {
 	_buttons &= ~button;
-
-	if(_autoReport) {
-		report();
-	}
+	TinyUSBDevices.newReport[TinyUSBDevices_::reportMouse] = true;
 }
   
  /*****************************
@@ -186,25 +173,21 @@ void AbsMouse5_::release(uint8_t button)
   Keyboard_::Keyboard_(void) {
   }
   
-  void Keyboard_::sendReport(KeyReport* keys)
+  void Keyboard_::report()
   {
     #if defined(ARDUINO_RASPBERRY_PI_PICO_W) && defined(ENABLE_CLASSIC)
-    if(TinyUSBDevices.onBattery) {
-      PicoBluetoothHID.send(HID_BT_KEYBOARD, keys, sizeof(keys));
-    } else {
-      if ( USBDevice.suspended() )  {
-        USBDevice.remoteWakeup();
-      }
+    // not actually sure if this is how kb reports should work in BT...
+    if(TinyUSBDevices.onBattery)
+      PicoBluetoothHID.send(HID_BT_KEYBOARD, _keyReport, sizeof(_keyReport));
+    else {
       while(!usbHid.ready()) yield();
-      usbHid.keyboardReport(HID_RID_KEYBOARD, keys->modifiers, keys->keys);
+      usbHid.keyboardReport(HID_RID_KEYBOARD, _keyReport.modifiers, _keyReport.keys);
     }
     #else
-    if ( USBDevice.suspended() )  {
-      USBDevice.remoteWakeup();
-    }
     while(!usbHid.ready()) yield();
-    usbHid.keyboardReport(HID_RID_KEYBOARD, keys->modifiers, keys->keys);
+    usbHid.keyboardReport(HID_RID_KEYBOARD, _keyReport.modifiers, _keyReport.keys);
     #endif // ARDUINO_RASPBERRY_PI_PICO_W
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportKeyboard] = false;
   }
   
   #define SHIFT 0x80
@@ -345,7 +328,7 @@ void AbsMouse5_::release(uint8_t button)
   // to the persistent key report and sends the report.  Because of the way 
   // USB HID works, the host acts like the key remains pressed until we 
   // call release(), releaseAll(), or otherwise clear the report and resend.
-  size_t Keyboard_::press(uint8_t k)
+  bool Keyboard_::press(uint8_t k)
   {
     uint8_t i;
     if (k >= 136) {     // it's a non-printing key (not a modifier)
@@ -357,7 +340,7 @@ void AbsMouse5_::release(uint8_t button)
       k = pgm_read_byte(_asciimap + k);
       if (!k) {
         setWriteError();
-        return 0;
+        return false;
       }
       if (k & 0x80) {           // it's a capital letter or other character reached with shift
         _keyReport.modifiers |= 0x02; // the left shift modifier
@@ -371,7 +354,7 @@ void AbsMouse5_::release(uint8_t button)
       _keyReport.keys[2] != k && _keyReport.keys[3] != k &&
       _keyReport.keys[4] != k && _keyReport.keys[5] != k) {
       
-      for (i=0; i<6; i++) {
+      for (i=0; i<6; ++i) {
         if (_keyReport.keys[i] == 0x00) {
           _keyReport.keys[i] = k;
           break;
@@ -379,17 +362,17 @@ void AbsMouse5_::release(uint8_t button)
       }
       if (i == 6) {
         setWriteError();
-        return 0;
+        return false;
       } 
     }
-    sendReport(&_keyReport);
-    return 1;
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportKeyboard] = true;
+    return true;
   }
   
   // release() takes the specified key out of the persistent key report and
   // sends the report.  This tells the OS the key is no longer pressed and that
   // it shouldn't be repeated any more.
-  size_t Keyboard_::release(uint8_t k)
+  bool Keyboard_::release(uint8_t k)
   {
     uint8_t i;
     if (k >= 136) {     // it's a non-printing key (not a modifier)
@@ -400,7 +383,7 @@ void AbsMouse5_::release(uint8_t button)
     } else {        // it's a printing key
       k = pgm_read_byte(_asciimap + k);
       if (!k) {
-        return 0;
+        return false;
       }
       if (k & 0x80) {             // it's a capital letter or other character reached with shift
         _keyReport.modifiers &= ~(0x02);  // the left shift modifier
@@ -410,13 +393,13 @@ void AbsMouse5_::release(uint8_t button)
     
     // Test the key report to see if k is present.  Clear it if it exists.
     // Check all positions in case the key is present more than once (which it shouldn't be)
-    for (i=0; i<6; i++) {
+    for (i=0; i<6; ++i) {
       if (0 != k && _keyReport.keys[i] == k) {
         _keyReport.keys[i] = 0x00;
       }
     }
-    sendReport(&_keyReport);
-    return 1;
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportKeyboard] = true;
+    return true;
   }
   
   void Keyboard_::releaseAll(void)
@@ -428,30 +411,20 @@ void AbsMouse5_::release(uint8_t button)
     _keyReport.keys[4] = 0;
     _keyReport.keys[5] = 0; 
     _keyReport.modifiers = 0;
-    sendReport(&_keyReport);
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportKeyboard] = true;
   }
-  
+
   size_t Keyboard_::write(uint8_t c)
   {
-    uint8_t p = press(c);  // Keydown
-    release(c);            // Keyup
-    return p;              // just return the result of press() since release() almost always returns 1
+    // stub
+    return 1;
+  }
+
+  size_t Keyboard_::write(const uint8_t *buffer, size_t size) {
+    // stub
+    return 1;
   }
   
-  size_t Keyboard_::write(const uint8_t *buffer, size_t size) {
-    size_t n = 0;
-    while (size--) {
-      if (*buffer != '\r') {
-        if (write(*buffer)) {
-          n++;
-        } else {
-          break;
-        }
-      }
-      buffer++;
-    }
-    return n;
-  }
   Keyboard_ Keyboard;//create an instance of the Keyboard object
 
 /*****************************
@@ -468,9 +441,7 @@ void AbsMouse5_::release(uint8_t button)
         gamepad16Report.Rx = map(origX, 0, 32767, -32767, 32767);
         gamepad16Report.Ry = map(origY, 0, 32767, -32767, 32767);
     }
-    if(_autoReport) {
-        report();
-    }
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = true;
   }
 
   void Gamepad16_::moveStick(uint16_t origX, uint16_t origY) {
@@ -484,31 +455,23 @@ void AbsMouse5_::release(uint8_t button)
             gamepad16Report.X = map(_x, 0, 4095, 32767, -32767);
             gamepad16Report.Y = map(_y, 0, 4095, 32767, -32767);
         }
-        if(_autoReport) {
-            report();
-        }
+        TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = true;
     }
   }
 
   void Gamepad16_::press(uint8_t buttonNum) {
     bitSet(gamepad16Report.buttons, buttonNum);
-    if(_autoReport) {
-        report();
-    }
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = true;
   }
 
   void Gamepad16_::release(uint8_t buttonNum) {
     bitClear(gamepad16Report.buttons, buttonNum);
-    if(_autoReport) {
-        report();
-    }
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = true;
   }
 
   void Gamepad16_::padUpdate(uint8_t padMask) {
     gamepad16Report.hat = padMask;
-    if(_autoReport) {
-        report();
-    }
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = true;
   }
 
   void Gamepad16_::report() {
@@ -517,19 +480,14 @@ void AbsMouse5_::release(uint8_t button)
       // this doesn't work for some reason :(
       //PicoBluetoothHID.send(2, &gamepad16Report, sizeof(gamepad16Report));
     } else {
-      if ( USBDevice.suspended() )  {
-        USBDevice.remoteWakeup();
-      }
       while(!usbHid.ready()) yield();
       usbHid.sendReport(HID_RID_GAMEPAD, &gamepad16Report, sizeof(gamepad16Report));
     }
     #else
-    if ( USBDevice.suspended() )  {
-      USBDevice.remoteWakeup();
-    }
     while(!usbHid.ready()) yield();
     usbHid.sendReport(HID_RID_GAMEPAD, &gamepad16Report, sizeof(gamepad16Report));
     #endif // ARDUINO_RASPBERRY_PI_PICO_W
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = false;
   }
 
   void Gamepad16_::releaseAll() {
@@ -539,7 +497,7 @@ void AbsMouse5_::release(uint8_t button)
     gamepad16Report.Y = 0;
     gamepad16Report.Rx = 0;
     gamepad16Report.Ry = 0;
-    report();
+    TinyUSBDevices.newReport[TinyUSBDevices_::reportGamepad] = true;
   }
 
 

--- a/libraries/TinyUSB_Devices/TinyUSB_Devices.h
+++ b/libraries/TinyUSB_Devices/TinyUSB_Devices.h
@@ -52,10 +52,26 @@
 
 class TinyUSBDevices_ {
 public:
-  TinyUSBDevices_(void);
-  void begin(byte polRate);
+  /// @brief Constructor
+  TinyUSBDevices_() {};
+
+  /// @brief Sends and initializes the array of USB devices to the connected host
+  void begin(int polRate);
+
+  /// @brief Sends and initializes the array of BT devices for paired devices
   void beginBT(const char *localName, const char *hidName);
+
+  /// @brief Whether the device is running in USB mode (false) or Bluetooth (true)
   bool onBattery = false;
+
+  enum reportChannels_e {
+      reportMouse = 0,
+      reportKeyboard,
+      reportGamepad
+  };
+
+  /// @brief Array of which of the three devices have new data that should be reported.
+  bool newReport[3] = { false, false, false };
 };
 extern TinyUSBDevices_ TinyUSBDevices;
 
@@ -114,12 +130,10 @@ private:
 	uint8_t _buttons;
 	uint16_t _x;
 	uint16_t _y;
-	bool _autoReport;
 
 public:
 	AbsMouse5_(uint8_t reportId = 1);
-	void init(bool autoReport = true);
-	void report(void);
+	void report();
 	void move(uint16_t x, uint16_t y);
 	void press(uint8_t b = MOUSE_LEFT);
 	void release(uint8_t b = MOUSE_LEFT);
@@ -203,13 +217,13 @@ extern AbsMouse5_ AbsMouse5;
   {
   private:
     KeyReport _keyReport;
-    void sendReport(KeyReport* keys);
   public:
     Keyboard_(void);
+    void report();
     size_t write(uint8_t k);
     size_t write(const uint8_t *buffer, size_t size);
-    size_t press(uint8_t k);
-    size_t release(uint8_t k);
+    bool press(uint8_t k);
+    bool release(uint8_t k);
     void releaseAll(void);
   };
 extern Keyboard_ Keyboard;
@@ -293,7 +307,6 @@ private:
   gamepad16Report_s gamepad16Report;
   uint16_t _x = 2048;
   uint16_t _y = 2048;
-  bool _autoReport = true;
 public:
   Gamepad16_(void);
   void moveCam(uint16_t origX, uint16_t origY);
@@ -303,7 +316,6 @@ public:
   void padUpdate(uint8_t padMask);
   void report(void);
   void releaseAll(void);
-  void setAutoreport(bool state) { _autoReport = state; }
   bool stickRight;
 };
 extern Gamepad16_ Gamepad16;


### PR DESCRIPTION
Previously, the buttons library would send a bespoke press event for *every individual button that's changed state*, which meant more than one button press, as unlikely as it is, would cause needless repeat blocking - especially if it's of the same type of report. Camera coords updates also served as its own potential blocker.

Now, we use a basic queue where every device update doesn't automatically report, but instead indicates that that USB device channel has a change that should be updated. The main loop (for either core) will update the status of the buttons/stick (if available) until the desired current polling interval is hit, where it will send out reports in an orderly fashion (with mouse events getting priority, naturally). 

For what it's worth, this has allowed for a truly 1000hz output for analog stick updates... so long as the mouse isn't active. Haven't checked yet if this is consistent while the FW's in gamepad output mode. 
![2025_04-22 000118](https://github.com/user-attachments/assets/de3ed06a-998d-4007-adfa-caeaa5aab62a)
For those interested, this is with analog movements while the mouse is active:
![2025_04-22 000322](https://github.com/user-attachments/assets/c4acd27a-da9c-4c12-a485-c067fde6e676)

There's also just some general cleanup surrounding things relating to inputs.

Note: the Keyboard "write" functions are just stubs, since I don't think there's ever a situation where we'll want to send a stream of keyboard data like full sentences...