### PR TITLE
Very basic temp throttling for solenoid serial ON commands

### DIFF
--- a/OpenFIREmain/OpenFIREFeedback.h
+++ b/OpenFIREmain/OpenFIREFeedback.h
@@ -48,6 +48,14 @@ public:
     // Current temperature as read from TMP36, in (approximate) Celsius
     static inline uint temperatureCurrent;
 
+    enum TempStatuses_e {
+        Temp_Safe = 0,
+        Temp_Warning,
+        Temp_Fatal
+    };
+
+    static inline TempStatuses_e tempStatus = Temp_Safe;     // Relative current state of the solenoid, according to TempStatuses_e
+
     #define TEMP_UPDATE_INTERVAL 250
 
 private:
@@ -58,14 +66,6 @@ private:
     static inline bool rumbleHappened = false;               // If we're holding, this marks we sent a rumble command already; is cleared when trigger is released
     
     static inline unsigned long previousMillisSol = 0;       // Timestamp of last time since unique solenoid state change
-
-    enum TempStatuses_e {
-        Temp_Safe = 0,
-        Temp_Warning,
-        Temp_Fatal
-    };
-
-    static inline TempStatuses_e tempStatus = Temp_Safe;               // Current state of the solenoid,
 
     // timer stuff
     static inline unsigned long currentMillis = 0;           // Current millis() value, which is globally updated/read across all functions in this class

--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -349,6 +349,23 @@ void OF_Serial::SerialProcessing()
                 switch(Serial.read()) {
                 // Solenoid "on" command
                 case '1':
+                    #ifdef USES_TEMP
+                    // block every other signal if temp is at warning threshold
+                    if(OF_Prefs::pins[OF_Const::tempPin] > -1) {
+                        switch(OF_FFB::tempStatus) {
+                        case OF_FFB::Temp_Safe:
+                            serialQueue[SerialQueue_Solenoid] = true;
+                            break;
+                        case OF_FFB::Temp_Warning:
+                            if(serialSolTempBuffer) serialQueue[SerialQueue_Solenoid] = true;
+                            serialSolTempBuffer = !serialSolTempBuffer;
+                            break;
+                        case OF_FFB::Temp_Fatal:
+                        default:
+                            break;
+                        }
+                    } else 
+                    #endif // USES_TEMP
                     serialQueue[SerialQueue_Solenoid] = true;
                     break;
                 // Solenoid "pulse" command (only if not already pulsing)

--- a/OpenFIREmain/OpenFIREserial.h
+++ b/OpenFIREmain/OpenFIREserial.h
@@ -94,6 +94,11 @@ private:
     static inline unsigned long serialSolTimestamp = 0;            // Timestamp of the last solenoid static on command (for safety)
     static inline uint serialSolCustomHoldLength = 0;              // Determines custom solenoid ON state length for sol "pulse" commands - 0 = use system settings
     static inline uint serialSolCustomPauseLength = 0;             // Determines custom solenoid OFF state length for sol "pulse" commands - 0 = use system settings
+    #ifdef USES_TEMP
+    // When tempStatus is above Temp_Safe, new static solenoid ON commands toggles this.
+    // False = disable solenoid ON command, True = allow solenoid ON command
+    static inline bool serialSolTempBuffer = false;
+    #endif // USES_TEMP
     #define SERIAL_SOLENOID_MAXSHUTOFF 2000
     #endif // USES_SOLENOID
 


### PR DESCRIPTION
If temp monitor is available, Solenoid Static ON signals in serial handoff mode are filtered depending on current temperature state (as determined in last FFB temperature update call):
 - No Sensor/Sensor @ good temp: No filtering
 - Sensor @ warning threshold: every other ON call is filtered
 - Sensor @ danger threshold: all ON calls are filtered