### PR TITLE
(Actually) Fix button re-mapping issues by copying button data to/from a backup descriptor array

### DIFF
--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -19,7 +19,7 @@
 #include "OpenFIRElights.h"
 #include "OpenFIREserial.h"
 
-// button object instance (defined in OpenFIREcommon.h)
+// button object instance (defined in OpenFIREcommon.h/OpenFIREprefs.h)
 LightgunButtons FW_Common::buttons(lgbData, ButtonCount);
 
 void FW_Common::FeedbackSet()

--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -1053,21 +1053,14 @@ void FW_Common::UpdateBindings(const bool &lowButtons)
 {
     if(gunMode != FW_Const::GunMode_Run) {
         // Updates pins
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Trigger].pin = OF_Prefs::pins[OF_Const::btnTrigger];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].pin       = OF_Prefs::pins[OF_Const::btnGunA];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].pin       = OF_Prefs::pins[OF_Const::btnGunB];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Reload].pin  = OF_Prefs::pins[OF_Const::btnGunC];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Start].pin   = OF_Prefs::pins[OF_Const::btnStart];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Select].pin  = OF_Prefs::pins[OF_Const::btnSelect];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Up].pin      = OF_Prefs::pins[OF_Const::btnGunUp];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Down].pin    = OF_Prefs::pins[OF_Const::btnGunDown];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Left].pin    = OF_Prefs::pins[OF_Const::btnGunLeft];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Right].pin   = OF_Prefs::pins[OF_Const::btnGunRight];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Pedal].pin   = OF_Prefs::pins[OF_Const::btnPedal];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Pedal2].pin  = OF_Prefs::pins[OF_Const::btnPedal2];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Pump].pin    = OF_Prefs::pins[OF_Const::btnPump];
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Home].pin    = OF_Prefs::pins[OF_Const::btnHome];
+        for(int i = 0; i < ButtonCount; ++i)
+            LightgunButtons::ButtonDesc[i].pin = OF_Prefs::pins[i];
     }
+
+    for(int i = 0; i < ButtonCount; ++i)
+        memcpy(&LightgunButtons::ButtonDesc[i].reportType,
+               OF_Prefs::backupButtonDesc[i],
+               sizeof(OF_Prefs::backupButtonDesc[0]));
 
     // Updates button functions for low-button mode
     if(lowButtons) {
@@ -1075,11 +1068,6 @@ void FW_Common::UpdateBindings(const bool &lowButtons)
         LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportCode2 = playerStartBtn;
         LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportType2 = LightgunButtons::ReportType_Keyboard;
         LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportCode2 = playerSelectBtn;
-    } else { // TODO: we should just reload btn config table from flash instead
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportType2 = LightgunButtons::ReportType_Mouse;
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportCode2 = MOUSE_RIGHT;
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportType2 = LightgunButtons::ReportType_Mouse;
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportCode2 = MOUSE_MIDDLE;
     }
 
     // update start/select button keyboard bindings
@@ -1087,7 +1075,4 @@ void FW_Common::UpdateBindings(const bool &lowButtons)
     LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Start].reportCode2  = playerStartBtn;
     LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Select].reportCode  = playerSelectBtn;
     LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Select].reportCode2 = playerSelectBtn;
-
-    LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Trigger].reportType2 = LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Trigger].reportType;
-    LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Trigger].reportCode2 = LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Trigger].reportCode;
 }

--- a/OpenFIREmain/OpenFIREcommon.h
+++ b/OpenFIREmain/OpenFIREcommon.h
@@ -185,49 +185,4 @@ public:
     #endif // USES_DISPLAY
 };
 
-// Sanity checks and assignments for player number -> common keyboard assignments
-    #if PLAYER_NUMBER == 1
-        static inline char playerStartBtn = '1';
-        static inline char playerSelectBtn = '5';
-    #elif PLAYER_NUMBER == 2
-        static inline char playerStartBtn = '2';
-        static inline char playerSelectBtn = '6';
-    #elif PLAYER_NUMBER == 3
-        static inline char playerStartBtn = '3';
-        static inline char playerSelectBtn = '7';
-    #elif PLAYER_NUMBER == 4
-        static inline char playerStartBtn = '4';
-        static inline char playerSelectBtn = '8';
-    #else
-        #error Undefined or out-of-range player number! Please set PLAYER_NUMBER to 1, 2, 3, or 4.
-    #endif // PLAYER_NUMBER
-
-// Button descriptor
-// The order of the buttons is the order of the button bitmask
-// must match ButtonIndex_e order, and the named bitmask values for each button
-// see LightgunButtons::Desc_t, format is: 
-// {pin, report type, report code (ignored for internal), offscreen report type, offscreen report code, gamepad output report type, gamepad output report code, debounce time, debounce mask, label}
-inline LightgunButtons::Desc_t LightgunButtons::ButtonDesc[] = {
-    {OF_Prefs::pins[OF_Const::btnTrigger],  LightgunButtons::ReportType_Mouse,    MOUSE_LEFT,      LightgunButtons::ReportType_Mouse,    MOUSE_LEFT,      LightgunButtons::ReportType_Gamepad,  PAD_RT,     15, BTN_AG_MASK}, // Barry says: "I'll handle this."
-    {OF_Prefs::pins[OF_Const::btnGunA],     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Gamepad,  PAD_LT,     15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnGunB],     LightgunButtons::ReportType_Mouse,    MOUSE_MIDDLE,    LightgunButtons::ReportType_Mouse,    MOUSE_MIDDLE,    LightgunButtons::ReportType_Gamepad,  PAD_Y,      15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnGunC],     LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Gamepad,  PAD_A,      15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnStart],    LightgunButtons::ReportType_Keyboard, playerStartBtn,  LightgunButtons::ReportType_Keyboard, playerStartBtn,  LightgunButtons::ReportType_Gamepad,  PAD_START,  20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnSelect],   LightgunButtons::ReportType_Keyboard, playerSelectBtn, LightgunButtons::ReportType_Keyboard, playerSelectBtn, LightgunButtons::ReportType_Gamepad,  PAD_SELECT, 20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnGunUp],    LightgunButtons::ReportType_Gamepad,  PAD_UP,          LightgunButtons::ReportType_Gamepad,  PAD_UP,          LightgunButtons::ReportType_Gamepad,  PAD_UP,     20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnGunDown],  LightgunButtons::ReportType_Gamepad,  PAD_DOWN,        LightgunButtons::ReportType_Gamepad,  PAD_DOWN,        LightgunButtons::ReportType_Gamepad,  PAD_DOWN,   20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnGunLeft],  LightgunButtons::ReportType_Gamepad,  PAD_LEFT,        LightgunButtons::ReportType_Gamepad,  PAD_LEFT,        LightgunButtons::ReportType_Gamepad,  PAD_LEFT,   20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnGunRight], LightgunButtons::ReportType_Gamepad,  PAD_RIGHT,       LightgunButtons::ReportType_Gamepad,  PAD_RIGHT,       LightgunButtons::ReportType_Gamepad,  PAD_RIGHT,  20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnPedal],    LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Gamepad,  PAD_X,      15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnPedal2],   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON5,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON5,   LightgunButtons::ReportType_Gamepad,  PAD_B,      15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnPump],     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Gamepad,  PAD_LT,     15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnHome],     LightgunButtons::ReportType_Internal, 0,               LightgunButtons::ReportType_Internal, 0,               LightgunButtons::ReportType_Internal, 0,          15, BTN_AG_MASK2}
-};
-
-    // button count constant
-    static inline constexpr unsigned int ButtonCount = sizeof(LightgunButtons::ButtonDesc) / sizeof(LightgunButtons::ButtonDesc[0]);
-
-    // button runtime data arrays
-    static inline LightgunButtonsStatic<ButtonCount> lgbData;
-
 #endif // _OPENFIRECOMMON_H_

--- a/OpenFIREmain/OpenFIREcommon.h
+++ b/OpenFIREmain/OpenFIREcommon.h
@@ -185,4 +185,7 @@ public:
     #endif // USES_DISPLAY
 };
 
+// button runtime data arrays
+static inline LightgunButtonsStatic<ButtonCount> lgbData;
+
 #endif // _OPENFIRECOMMON_H_

--- a/OpenFIREmain/OpenFIREprefs.cpp
+++ b/OpenFIREmain/OpenFIREprefs.cpp
@@ -25,6 +25,9 @@ void OF_Prefs::Load()
     if(toggles[OF_Const::customPins]) LoadPins();
     LoadSettings();
     LoadUSBID();
+
+    for(int i = 0; i < ButtonCount; ++i)
+        memcpy(OF_Prefs::backupButtonDesc[i], &LightgunButtons::ButtonDesc[i].reportType, sizeof(OF_Prefs::backupButtonDesc[i]));
 }
 
 int OF_Prefs::LoadProfiles()

--- a/OpenFIREmain/OpenFIREprefs.h
+++ b/OpenFIREmain/OpenFIREprefs.h
@@ -230,7 +230,4 @@ static inline constexpr unsigned int ButtonCount = sizeof(LightgunButtons::Butto
 
 inline uint8_t OF_Prefs::backupButtonDesc[ButtonCount][6];
 
-// button runtime data arrays
-static inline LightgunButtonsStatic<ButtonCount> lgbData;
-
 #endif // _OPENFIREPREFS_H_

--- a/OpenFIREmain/OpenFIREprefs.h
+++ b/OpenFIREmain/OpenFIREprefs.h
@@ -22,9 +22,12 @@
 #include <LittleFS.h>
 #include <OpenFIREBoard.h>
 #include <DFRobotIRPositionEx.h>
+#include <LightgunButtons.h>
+#include <TinyUSB_Devices.h>
 
 #include "boards/OpenFIREshared.h"
 #include "OpenFIREDefines.h"
+#include "OpenFIREconstant.h"
 
 /// @brief Static instance of preferences to save in non-volatile memory
 class OF_Prefs
@@ -115,6 +118,9 @@ public:
         { 'F', 'I', 'R', 'E', 'C', 'o', 'n', ' ', 'P', PLAYER_NUMBER+'0' }
     };
 
+    // Backup instance of the buttons descriptor
+    static uint8_t backupButtonDesc[][6];
+
     /// @brief Instance of OpenFIREshared's presets and I/O table data
     static inline OF_Const OFPresets;
 
@@ -179,5 +185,52 @@ public:
     /// @brief Sets pre-set values according to the board
     static void LoadPresets();
 };
+
+// Sanity checks and assignments for player number -> common keyboard assignments
+    #if PLAYER_NUMBER == 1
+        static inline char playerStartBtn = '1';
+        static inline char playerSelectBtn = '5';
+    #elif PLAYER_NUMBER == 2
+        static inline char playerStartBtn = '2';
+        static inline char playerSelectBtn = '6';
+    #elif PLAYER_NUMBER == 3
+        static inline char playerStartBtn = '3';
+        static inline char playerSelectBtn = '7';
+    #elif PLAYER_NUMBER == 4
+        static inline char playerStartBtn = '4';
+        static inline char playerSelectBtn = '8';
+    #else
+        #error Undefined or out-of-range player number! Please set PLAYER_NUMBER to 1, 2, 3, or 4.
+    #endif // PLAYER_NUMBER
+
+// Button descriptor
+// The order of the buttons is the order of the button bitmask
+// must match ButtonIndex_e order, and the named bitmask values for each button
+// see LightgunButtons::Desc_t, format is: 
+// {pin, report type, report code (ignored for internal), offscreen report type, offscreen report code, gamepad output report type, gamepad output report code, debounce time, debounce mask, label}
+inline LightgunButtons::Desc_t LightgunButtons::ButtonDesc[] = {
+    {OF_Prefs::pins[OF_Const::btnTrigger],  LightgunButtons::ReportType_Mouse,    MOUSE_LEFT,      LightgunButtons::ReportType_Mouse,    MOUSE_LEFT,      LightgunButtons::ReportType_Gamepad,  PAD_RT,     15, BTN_AG_MASK}, // Barry says: "I'll handle this."
+    {OF_Prefs::pins[OF_Const::btnGunA],     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Gamepad,  PAD_LT,     15, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnGunB],     LightgunButtons::ReportType_Mouse,    MOUSE_MIDDLE,    LightgunButtons::ReportType_Mouse,    MOUSE_MIDDLE,    LightgunButtons::ReportType_Gamepad,  PAD_Y,      15, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnGunC],     LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Gamepad,  PAD_A,      15, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnStart],    LightgunButtons::ReportType_Keyboard, playerStartBtn,  LightgunButtons::ReportType_Keyboard, playerStartBtn,  LightgunButtons::ReportType_Gamepad,  PAD_START,  20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnSelect],   LightgunButtons::ReportType_Keyboard, playerSelectBtn, LightgunButtons::ReportType_Keyboard, playerSelectBtn, LightgunButtons::ReportType_Gamepad,  PAD_SELECT, 20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnGunUp],    LightgunButtons::ReportType_Gamepad,  PAD_UP,          LightgunButtons::ReportType_Gamepad,  PAD_UP,          LightgunButtons::ReportType_Gamepad,  PAD_UP,     20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnGunDown],  LightgunButtons::ReportType_Gamepad,  PAD_DOWN,        LightgunButtons::ReportType_Gamepad,  PAD_DOWN,        LightgunButtons::ReportType_Gamepad,  PAD_DOWN,   20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnGunLeft],  LightgunButtons::ReportType_Gamepad,  PAD_LEFT,        LightgunButtons::ReportType_Gamepad,  PAD_LEFT,        LightgunButtons::ReportType_Gamepad,  PAD_LEFT,   20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnGunRight], LightgunButtons::ReportType_Gamepad,  PAD_RIGHT,       LightgunButtons::ReportType_Gamepad,  PAD_RIGHT,       LightgunButtons::ReportType_Gamepad,  PAD_RIGHT,  20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnPedal],    LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Gamepad,  PAD_X,      15, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnPedal2],   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON5,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON5,   LightgunButtons::ReportType_Gamepad,  PAD_B,      15, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnPump],     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Gamepad,  PAD_LT,     15, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnHome],     LightgunButtons::ReportType_Internal, 0,               LightgunButtons::ReportType_Internal, 0,               LightgunButtons::ReportType_Internal, 0,          15, BTN_AG_MASK2}
+};
+
+// button count constant
+static inline constexpr unsigned int ButtonCount = sizeof(LightgunButtons::ButtonDesc) / sizeof(LightgunButtons::ButtonDesc[0]);
+
+inline uint8_t OF_Prefs::backupButtonDesc[ButtonCount][6];
+
+// button runtime data arrays
+static inline LightgunButtonsStatic<ButtonCount> lgbData;
 
 #endif // _OPENFIREPREFS_H_


### PR DESCRIPTION
Didn't think I would have to implement this so soon, but may as well get it ready now lol.

(This is actually one of two prereqs for user-exposed button function remapping)