### PR TITLE
for compatibility with Esp32 - Update OpenFIREserial.cpp

### DIFF
--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -1136,7 +1136,7 @@ void OF_Serial::SerialBatchSend(void *dataPtr, const std::unordered_map<std::str
             for(int sendTry = 0; sendTry < 3; ++sendTry) {
                 Serial.write(TXbuf, pos);
                 Serial.flush();
-                while(Serial.available() < pos) {}
+                while(Serial.available() < pos) yield();
                 Serial.readBytes(RXbuf, Serial.available());
 
                 if(!memcmp(RXbuf, TXbuf, pos)) break;


### PR DESCRIPTION
For esp32 compatibility ... so it works on both rp2040 and esp32

In empty loops esp32, using freertos, needs yield(), which is a function that does nothing, but gives control to other tasks .. on rp2040 it has no effect