### PR TITLE
Add full remappable button mappings, Analog-to-Digital presets

### DIFF
--- a/OpenFIREmain/OpenFIREDefines.h
+++ b/OpenFIREmain/OpenFIREDefines.h
@@ -31,13 +31,32 @@
   // Here we define the Manufacturer Name, Device Name, and Vendor ID of the gun as will be displayed by the operating system.
   // For multiplayer, different guns need different IDs!
   // If unsure, just leave these at their defaults, as Product ID is determined by what's saved in local storage, or Player Number as a fallback.
+  // For compatibility with some whitelists' support for OpenFIRE, Manufacturer Name and Device VID must be kept at the default values "OpenFIRE"/OxF143
 #define MANUFACTURER_NAME "OpenFIRE"
 #define DEVICE_NAME "FIRECon"
 #define DEVICE_VID 0xF143
 
-  // Set what player this board is mapped to by default (1-4). This will change keyboard mappings appropriate for the respective player.
-  // If unsure, just leave this at 1 - the mapping can be changed at runtime by sending an 'XR#' command over Serial, where # = player number
-#define PLAYER_NUMBER 1
+  // Set what player this board is hardcoded to.
+  // This will change the function of playerStartBtn/playerSelectBtn appropriate for the respective player, regardless of Product ID.
+  // If unsure, just leave commented out - the mapping is adjusted dynamically based on Product ID,
+  // and can be changed at runtime by sending an 'XR#' command over Serial, where # = player number.
+//#define PLAYER_NUMBER 1
+
+#ifdef PLAYER_NUMBER
+#if PLAYER_NUMBER == 1
+#define PLAYER_START '1'
+#define PLAYER_SELECT '5'
+#elif PLAYER_NUMBER == 2
+#define PLAYER_START '2'
+#define PLAYER_SELECT '6'
+#elif PLAYER_NUMBER == 3
+#define PLAYER_START '3'
+#define PLAYER_SELECT '7'
+#elif PLAYER_NUMBER == 4
+#define PLAYER_START '4'
+#define PLAYER_SELECT '8'
+#endif // PLAYER_NUMBER
+#endif // PLAYER_NUMBER
 
   // Leave this uncommented to enable MAMEHOOKER support, or comment out (//) to disable references to serial reading and only use it for debugging.
   // WARNING: Has a chance of making the board lock up if TinyUSB hasn't been patched to fix serial-related lockups.

--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -993,6 +993,7 @@ int FW_Common::SavePreferences()
             OF_Prefs::SavePins();
 
         OF_Prefs::SaveSettings();
+        OF_Prefs::SaveButtons();
         OF_Prefs::SaveUSBID();
 
         #ifdef LED_ENABLE
@@ -1054,22 +1055,46 @@ void FW_Common::UpdateBindings(const bool &lowButtons)
             LightgunButtons::ButtonDesc[i].pin = OF_Prefs::pins[i];
     }
 
-    for(int i = 0; i < ButtonCount; ++i)
+    #if defined(PLAYER_START) && defined(PLAYER_SELECT)
+    playerStartBtn = PLAYER_START;
+    playerSelectBtn = PLAYER_SELECT;
+    #else
+    if(OF_Prefs::usb.devicePID > 0 && OF_Prefs::usb.devicePID < 5) {
+        playerStartBtn = OF_Prefs::usb.devicePID + '0';
+        playerSelectBtn = OF_Prefs::usb.devicePID + '4';
+    } else {
+        playerStartBtn = '1';
+        playerSelectBtn = '5';
+    }
+    #endif // PLAYER_NUMBER
+
+    for(int i = 0; i < ButtonCount; ++i) {
         memcpy(&LightgunButtons::ButtonDesc[i].reportType,
                OF_Prefs::backupButtonDesc[i],
                sizeof(OF_Prefs::backupButtonDesc[0]));
+        
+        while(true) {
+            uint8_t *ptr = (uint8_t*)memchr(&LightgunButtons::ButtonDesc[i].reportCode, 0xFF, sizeof(OF_Prefs::backupButtonDesc[i]-1));
+            if(ptr != nullptr)
+                *ptr = playerStartBtn;
+            else break;
+        }
+
+        while(true) {
+            uint8_t *ptr = (uint8_t*)memchr(&LightgunButtons::ButtonDesc[i].reportCode, 0xFE, sizeof(OF_Prefs::backupButtonDesc[i]-1));
+            if(ptr != nullptr)
+                *ptr = playerSelectBtn;
+            else break;
+        }
+    }
 
     // Updates button functions for low-button mode
     if(lowButtons) {
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportType2 = LightgunButtons::ReportType_Keyboard;
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportCode2 = playerStartBtn;
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportType2 = LightgunButtons::ReportType_Keyboard;
-        LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportCode2 = playerSelectBtn;
+        memcpy(&LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportType2,
+               OF_Prefs::backupButtonDesc[FW_Const::BtnIdx_Start],
+               2);
+        memcpy(&LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportType2,
+               OF_Prefs::backupButtonDesc[FW_Const::BtnIdx_Select],
+               2);
     }
-
-    // update start/select button keyboard bindings
-    LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Start].reportCode   = playerStartBtn;
-    LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Start].reportCode2  = playerStartBtn;
-    LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Select].reportCode  = playerSelectBtn;
-    LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Select].reportCode2 = playerSelectBtn;
 }

--- a/OpenFIREmain/OpenFIREcommon.h
+++ b/OpenFIREmain/OpenFIREcommon.h
@@ -164,6 +164,7 @@ public:
 
     #ifdef USES_ANALOG
         static inline bool analogIsValid;                          // Flag set true if analog stick is mapped to valid nums
+        static inline uint32_t aStickADCLastPos = 0;               // Analog-to-digital direction mask for digital outputs when settings[OF_Const::analogMode] is > 0
     #endif // USES_ANALOG
 
     #ifdef FOURPIN_LED
@@ -181,6 +182,9 @@ public:
     #endif // MAMEHOOKER
     #endif // USES_DISPLAY
 };
+
+static inline char playerStartBtn = '1';
+static inline char playerSelectBtn = '5';
 
 // button runtime data arrays
 static inline LightgunButtonsStatic<ButtonCount> lgbData;

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -1038,9 +1038,9 @@ void AnalogStickPoll()
         switch(OF_Prefs::settings[OF_Const::analogMode]) {
         case OF_Const::analogModeDpad: Gamepad16.padUpdate(FW_Common::buttons.PadMaskConvert(newPos)); break;
         case OF_Const::analogModeKeys:
-            if(FW_Common::aStickADCLastPos & newPos) {
+            if(FW_Common::aStickADCLastPos ^ newPos) {
                 for(int i = 0; i < 4; ++i) {
-                    if(FW_Common::aStickADCLastPos & (newPos & 1 << i))
+                    if(FW_Common::aStickADCLastPos ^ newPos & 1 << i)
                         Keyboard.release(KEY_UP_ARROW-i);
                 }
             }

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -90,7 +90,13 @@ void setup() {
             else TinyUSBDevice.setProductDescriptor(OF_Prefs::usb.deviceName);
         } else {
             TinyUSBDevice.setProductDescriptor(DEVICE_NAME);
-            TinyUSBDevice.setID(DEVICE_VID, PLAYER_NUMBER);
+            TinyUSBDevice.setID(DEVICE_VID,
+            #ifdef PLAYER_NUMBER
+            PLAYER_NUMBER
+            #else
+            1
+            #endif // PLAYER_NUMBER
+            );
         }
 
         #if defined(ARDUINO_RASPBERRY_PI_PICO_W) && defined(ENABLE_CLASSIC)
@@ -117,11 +123,6 @@ void setup() {
         Serial.setTimeout(0);
         #endif // ARDUINO_RASPBERRY_PI_PICO_W
     #endif // USE_TINYUSB
-
-    if(OF_Prefs::usb.devicePID > 0 && OF_Prefs::usb.devicePID < 5) {
-        playerStartBtn = OF_Prefs::usb.devicePID + '0';
-        playerSelectBtn = OF_Prefs::usb.devicePID + '4';
-    }
 
     // this is needed for both customs and builtins, as defaults are all uninitialized
     FW_Common::UpdateBindings(OF_Prefs::toggles[OF_Const::lowButtonsMode]);
@@ -1007,17 +1008,50 @@ void TriggerNotFire()
 #ifdef USES_ANALOG
 void AnalogStickPoll()
 {
-    unsigned int analogValueX = analogRead(OF_Prefs::pins[OF_Const::analogX]);
-    unsigned int analogValueY = analogRead(OF_Prefs::pins[OF_Const::analogY]);
+    int analogValueX = analogRead(OF_Prefs::pins[OF_Const::analogX]);
+    int analogValueY = analogRead(OF_Prefs::pins[OF_Const::analogY]);
     
-    // Analog stick deadzone should help mitigate overwriting USB commands for the other input channels.
-    if((analogValueX < 1900 || analogValueX > 2200) ||
-       (analogValueY < 1900 || analogValueY > 2200)) {
-          Gamepad16.moveStick(analogValueX, analogValueY);
+    if(OF_Prefs::settings[OF_Const::analogMode] == OF_Const::analogModeStick) {
+        // Analog stick deadzone should help mitigate overwriting USB commands for the other input channels.
+        if((analogValueX < 1900 || analogValueX > 2200) ||
+        (analogValueY < 1900 || analogValueY > 2200)) {
+            Gamepad16.moveStick(analogValueX, analogValueY);
+        } else {
+            // Duplicate coords won't be reported, so no worries.
+            Gamepad16.moveStick(2048, 2048);
+        }
     } else {
-        // Duplicate coords won't be reported, so no worries.
-        Gamepad16.moveStick(2048, 2048);
+        uint32_t newPos = 0;
+
+        // TODO: need to consider inverted axis toggle, currently assumes axises are inverted by default
+        if(analogValueY < 1900)
+            newPos = 2; // down
+        else if(analogValueY > 2200)
+            newPos = 1; // up
+
+        if(analogValueX < 1900)
+            newPos |= 8; // right?
+        else if(analogValueX > 2200)
+            newPos |= 4; // left?
+
+        switch(OF_Prefs::settings[OF_Const::analogMode]) {
+        case OF_Const::analogModeDpad: Gamepad16.padUpdate(LightgunButtons::MaskToIndex(newPos)); break;
+        case OF_Const::analogModeKeys:
+            if(FW_Common::aStickADCLastPos & newPos) {
+                for(int i = 0; i < 4; ++i) {
+                    if(FW_Common::aStickADCLastPos & (newPos & 1 << i))
+                        Keyboard.release(KEY_UP_ARROW-i);
+                }
+            }
+            for(int i = 0; i < 4; ++i) {
+                if(newPos & 1 << i)
+                    Keyboard.press(KEY_UP_ARROW-i);
+            }
+            break;
+        }
+        FW_Common::aStickADCLastPos = newPos;
     }
+        
 }
 #endif // USES_ANALOG
 

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -1024,15 +1024,16 @@ void AnalogStickPoll()
         uint32_t newPos = 0;
 
         // TODO: need to consider inverted axis toggle, currently assumes axises are inverted by default
-        if(analogValueY < 1900)
+        // would this also benefit from custom Analog->Digital deadzone?
+        if(analogValueY < 1200)
             newPos = 2; // down
-        else if(analogValueY > 2200)
+        else if(analogValueY > 2900)
             newPos = 1; // up
 
-        if(analogValueX < 1900)
-            newPos |= 8; // right?
-        else if(analogValueX > 2200)
-            newPos |= 4; // left?
+        if(analogValueX < 1200)
+            newPos |= 8; // right
+        else if(analogValueX > 2900)
+            newPos |= 4; // left
 
         switch(OF_Prefs::settings[OF_Const::analogMode]) {
         case OF_Const::analogModeDpad: Gamepad16.padUpdate(FW_Common::buttons.PadMaskConvert(newPos)); break;

--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -1035,7 +1035,7 @@ void AnalogStickPoll()
             newPos |= 4; // left?
 
         switch(OF_Prefs::settings[OF_Const::analogMode]) {
-        case OF_Const::analogModeDpad: Gamepad16.padUpdate(LightgunButtons::MaskToIndex(newPos)); break;
+        case OF_Const::analogModeDpad: Gamepad16.padUpdate(FW_Common::buttons.PadMaskConvert(newPos)); break;
         case OF_Const::analogModeKeys:
             if(FW_Common::aStickADCLastPos & newPos) {
                 for(int i = 0; i < 4; ++i) {

--- a/OpenFIREmain/OpenFIREprefs.cpp
+++ b/OpenFIREmain/OpenFIREprefs.cpp
@@ -25,9 +25,9 @@ void OF_Prefs::Load()
     if(toggles[OF_Const::customPins]) LoadPins();
     LoadSettings();
     LoadUSBID();
-
+    LoadButtons();
     for(int i = 0; i < ButtonCount; ++i)
-        memcpy(OF_Prefs::backupButtonDesc[i], &LightgunButtons::ButtonDesc[i].reportType, sizeof(OF_Prefs::backupButtonDesc[i]));
+        memcpy(&LightgunButtons::ButtonDesc[i].reportType, OF_Prefs::backupButtonDesc[i], sizeof(OF_Prefs::backupButtonDesc[i]));
 }
 
 int OF_Prefs::LoadProfiles()
@@ -112,7 +112,7 @@ int OF_Prefs::SaveToPtr(File prefsFile, void *dataPtr, const std::unordered_map<
 {
     if(prefsFile) {
         for(auto &pair : mapPtr) {
-            if(pair.second >= 0) {
+            if((pair.second >= 0 && dataPtr != backupButtonDesc) || dataPtr == backupButtonDesc && pair.second >= 0 && pair.second < ButtonCount) {
                 prefsFile.write((const uint8_t*)pair.first.c_str(), pair.first.length()+1);
                 prefsFile.write((uint8_t)dataSize);
                 prefsFile.write((uint8_t*)dataPtr + (dataSize * pair.second), dataSize);
@@ -181,4 +181,9 @@ void OF_Prefs::LoadPresets()
             if(OFPresets.boardsPresetsMap.at(OPENFIRE_BOARD).at(i) > -1)
                 pins[OFPresets.boardsPresetsMap.at(OPENFIRE_BOARD).at(i)] = i;
     }
+
+    // save buttons map to backup descriptor (important for initializing backupDesc for saving)
+    // couldn't find a better place for this tbh lol
+    for(int i = 0; i < ButtonCount; ++i)
+        memcpy(OF_Prefs::backupButtonDesc[i], &LightgunButtons::ButtonDesc[i].reportType, sizeof(OF_Prefs::backupButtonDesc[i]));
 }

--- a/OpenFIREmain/OpenFIREprefs.h
+++ b/OpenFIREmain/OpenFIREprefs.h
@@ -92,19 +92,20 @@ public:
 
     /// @brief System variables array
     static inline uint32_t settings[OF_Const::settingsTypesCount] = {
-        255,            // rumble strength
-        150,            // rumble length
-        45,             // solenoid on length
-        80,             // solenoid off length
-        500,            // solenoid hold length
-        2500,           // hold-to-pause length
-        1,              // custom NeoPixel strand length
-        0,              // custom NeoPixel static count
-        0xFF0000,       // custom pixel color 1
-        0x00FF00,       // custom pixel color 2
-        0x0000FF,       // custom pixel color 3
-        38,             // temp warning
-        45,             // temp shutoff
+        255,                        // rumble strength
+        150,                        // rumble length
+        45,                         // solenoid on length
+        80,                         // solenoid off length
+        500,                        // solenoid hold length
+        2500,                       // hold-to-pause length
+        1,                          // custom NeoPixel strand length
+        0,                          // custom NeoPixel static count
+        0xFF0000,                   // custom pixel color 1
+        0x00FF00,                   // custom pixel color 2
+        0x0000FF,                   // custom pixel color 3
+        38,                         // temp warning
+        45,                         // temp shutoff
+        OF_Const::analogModeStick,  // analog stick mode
     };
 
     typedef struct USBMap_s {
@@ -114,8 +115,13 @@ public:
 
     /// @brief Instance of TinyUSB identifier data
     static inline USBMap_t usb = {
+        #ifdef PLAYER_NUMBER
         PLAYER_NUMBER,
         { 'F', 'I', 'R', 'E', 'C', 'o', 'n', ' ', 'P', PLAYER_NUMBER+'0' }
+        #else
+        1,
+        { 'F', 'I', 'R', 'E', 'C', 'o', 'n', ' ', 'P', '1' }
+        #endif // PLAYER_NUMBER
     };
 
     // Backup instance of the buttons descriptor
@@ -149,27 +155,35 @@ public:
 
     /// @brief Load toggles (macro for LoadToPtr)
     /// @return An error code from Errors_e
-    static int LoadToggles() { return LoadToPtr(LittleFS.open("/toggles.conf", "r"), &toggles, OFPresets.boolTypes_Strings); }
+    static int LoadToggles() { return LoadToPtr(LittleFS.open("/toggles.conf", "r"), toggles, OFPresets.boolTypes_Strings); }
 
     /// @brief Save current toggles states (macro for SaveToPtr)
     /// @return An error code from Errors_e
-    static int SaveToggles() { return SaveToPtr(LittleFS.open("/toggles.conf", "w"), &toggles, OFPresets.boolTypes_Strings, sizeof(toggles) / OF_Const::boolTypesCount); }
+    static int SaveToggles() { return SaveToPtr(LittleFS.open("/toggles.conf", "w"), toggles, OFPresets.boolTypes_Strings, sizeof(toggles) / OF_Const::boolTypesCount); }
 
     /// @brief Load pin mapping (macro for LoadToPtr)
     /// @return An error code from Errors_e
-    static int LoadPins() { return LoadToPtr(LittleFS.open("/pins.conf", "r"), &pins, OFPresets.boardInputs_Strings); }
+    static int LoadPins() { return LoadToPtr(LittleFS.open("/pins.conf", "r"), pins, OFPresets.boardInputs_Strings); }
 
     /// @brief Save current pin mapping (macro for SaveToPtr)
     /// @return An error code from Errors_e
-    static int SavePins() { return SaveToPtr(LittleFS.open("/pins.conf", "w"), &pins, OFPresets.boardInputs_Strings, sizeof(pins) / OF_Const::boardInputsCount); }
+    static int SavePins() { return SaveToPtr(LittleFS.open("/pins.conf", "w"), pins, OFPresets.boardInputs_Strings, sizeof(pins) / OF_Const::boardInputsCount); }
 
     /// @brief Load settings (macro for LoadToPtr)
     /// @return An error code from Errors_e
-    static int LoadSettings() { return LoadToPtr(LittleFS.open("/settings.conf", "r"), &settings, OFPresets.settingsTypes_Strings); }
+    static int LoadSettings() { return LoadToPtr(LittleFS.open("/settings.conf", "r"), settings, OFPresets.settingsTypes_Strings); }
 
     /// @brief Save current settings (macro for SaveToPtr)
     /// @return An error code from Errors_e
-    static int SaveSettings() { return SaveToPtr(LittleFS.open("/settings.conf", "w"), &settings, OFPresets.settingsTypes_Strings, sizeof(settings) / OF_Const::settingsTypesCount); }
+    static int SaveSettings() { return SaveToPtr(LittleFS.open("/settings.conf", "w"), settings, OFPresets.settingsTypes_Strings, sizeof(settings) / OF_Const::settingsTypesCount); }
+
+    /// @brief Load settings (macro for LoadToPtr)
+    /// @return An error code from Errors_e
+    static int LoadButtons() { return LoadToPtr(LittleFS.open("/btns.conf", "r"), backupButtonDesc, OFPresets.boardInputs_Strings); }
+
+    /// @brief Save current settings (macro for SaveToPtr)
+    /// @return An error code from Errors_e
+    static int SaveButtons();
 
     /// @brief Load USB identifier info
     /// @return An error code from Errors_e
@@ -186,23 +200,6 @@ public:
     static void LoadPresets();
 };
 
-// Sanity checks and assignments for player number -> common keyboard assignments
-    #if PLAYER_NUMBER == 1
-        static inline char playerStartBtn = '1';
-        static inline char playerSelectBtn = '5';
-    #elif PLAYER_NUMBER == 2
-        static inline char playerStartBtn = '2';
-        static inline char playerSelectBtn = '6';
-    #elif PLAYER_NUMBER == 3
-        static inline char playerStartBtn = '3';
-        static inline char playerSelectBtn = '7';
-    #elif PLAYER_NUMBER == 4
-        static inline char playerStartBtn = '4';
-        static inline char playerSelectBtn = '8';
-    #else
-        #error Undefined or out-of-range player number! Please set PLAYER_NUMBER to 1, 2, 3, or 4.
-    #endif // PLAYER_NUMBER
-
 // Button descriptor
 // The order of the buttons is the order of the button bitmask
 // must match ButtonIndex_e order, and the named bitmask values for each button
@@ -213,8 +210,8 @@ inline LightgunButtons::Desc_t LightgunButtons::ButtonDesc[] = {
     {OF_Prefs::pins[OF_Const::btnGunA],     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Mouse,    MOUSE_RIGHT,     LightgunButtons::ReportType_Gamepad,  PAD_LT,     15, BTN_AG_MASK2},
     {OF_Prefs::pins[OF_Const::btnGunB],     LightgunButtons::ReportType_Mouse,    MOUSE_MIDDLE,    LightgunButtons::ReportType_Mouse,    MOUSE_MIDDLE,    LightgunButtons::ReportType_Gamepad,  PAD_Y,      15, BTN_AG_MASK2},
     {OF_Prefs::pins[OF_Const::btnGunC],     LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Mouse,    MOUSE_BUTTON4,   LightgunButtons::ReportType_Gamepad,  PAD_A,      15, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnStart],    LightgunButtons::ReportType_Keyboard, playerStartBtn,  LightgunButtons::ReportType_Keyboard, playerStartBtn,  LightgunButtons::ReportType_Gamepad,  PAD_START,  20, BTN_AG_MASK2},
-    {OF_Prefs::pins[OF_Const::btnSelect],   LightgunButtons::ReportType_Keyboard, playerSelectBtn, LightgunButtons::ReportType_Keyboard, playerSelectBtn, LightgunButtons::ReportType_Gamepad,  PAD_SELECT, 20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnStart],    LightgunButtons::ReportType_Keyboard, 0xFF,            LightgunButtons::ReportType_Keyboard, 0xFF,            LightgunButtons::ReportType_Gamepad,  PAD_START,  20, BTN_AG_MASK2},
+    {OF_Prefs::pins[OF_Const::btnSelect],   LightgunButtons::ReportType_Keyboard, 0xFE,            LightgunButtons::ReportType_Keyboard, 0xFE,            LightgunButtons::ReportType_Gamepad,  PAD_SELECT, 20, BTN_AG_MASK2},
     {OF_Prefs::pins[OF_Const::btnGunUp],    LightgunButtons::ReportType_Gamepad,  PAD_UP,          LightgunButtons::ReportType_Gamepad,  PAD_UP,          LightgunButtons::ReportType_Gamepad,  PAD_UP,     20, BTN_AG_MASK2},
     {OF_Prefs::pins[OF_Const::btnGunDown],  LightgunButtons::ReportType_Gamepad,  PAD_DOWN,        LightgunButtons::ReportType_Gamepad,  PAD_DOWN,        LightgunButtons::ReportType_Gamepad,  PAD_DOWN,   20, BTN_AG_MASK2},
     {OF_Prefs::pins[OF_Const::btnGunLeft],  LightgunButtons::ReportType_Gamepad,  PAD_LEFT,        LightgunButtons::ReportType_Gamepad,  PAD_LEFT,        LightgunButtons::ReportType_Gamepad,  PAD_LEFT,   20, BTN_AG_MASK2},
@@ -229,5 +226,7 @@ inline LightgunButtons::Desc_t LightgunButtons::ButtonDesc[] = {
 static inline constexpr unsigned int ButtonCount = sizeof(LightgunButtons::ButtonDesc) / sizeof(LightgunButtons::ButtonDesc[0]);
 
 inline uint8_t OF_Prefs::backupButtonDesc[ButtonCount][6];
+
+inline int OF_Prefs::SaveButtons() { return SaveToPtr(LittleFS.open("/btns.conf", "w"), backupButtonDesc, OFPresets.boardInputs_Strings, sizeof(backupButtonDesc) / ButtonCount); }
 
 #endif // _OPENFIREPREFS_H_

--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -920,9 +920,10 @@ void OF_Serial::SerialProcessingDocked()
         
     //// Prefs senders
     //
-    case OF_Const::sGetToggles:  SerialBatchSend(&OF_Prefs::toggles,  OF_Prefs::OFPresets.boolTypes_Strings,     sizeof(OF_Prefs::toggles)  / OF_Const::boolTypesCount    ); break;
-    case OF_Const::sGetPins:     SerialBatchSend(&OF_Prefs::pins,     OF_Prefs::OFPresets.boardInputs_Strings,   sizeof(OF_Prefs::pins)     / OF_Const::boardInputsCount  ); break;
-    case OF_Const::sGetSettings: SerialBatchSend(&OF_Prefs::settings, OF_Prefs::OFPresets.settingsTypes_Strings, sizeof(OF_Prefs::settings) / OF_Const::settingsTypesCount); break;
+    case OF_Const::sGetToggles:  SerialBatchSend(OF_Prefs::toggles,          OF_Prefs::OFPresets.boolTypes_Strings,     sizeof(OF_Prefs::toggles)          / OF_Const::boolTypesCount    ); break;
+    case OF_Const::sGetPins:     SerialBatchSend(OF_Prefs::pins,             OF_Prefs::OFPresets.boardInputs_Strings,   sizeof(OF_Prefs::pins)             / OF_Const::boardInputsCount  ); break;
+    case OF_Const::sGetSettings: SerialBatchSend(OF_Prefs::settings,         OF_Prefs::OFPresets.settingsTypes_Strings, sizeof(OF_Prefs::settings)         / OF_Const::settingsTypesCount); break;
+    case OF_Const::sGetBtns:     SerialBatchSend(OF_Prefs::backupButtonDesc, OF_Prefs::OFPresets.boardInputs_Strings,   sizeof(OF_Prefs::backupButtonDesc) / ButtonCount);                  break;
     case OF_Const::sGetProfile:
         for(int prof = 0; prof < PROFILE_COUNT; ++prof)
             SerialBatchSend(&OF_Prefs::profiles[prof], OF_Prefs::OFPresets.profSettingTypes_Strings, sizeof(uint32_t), prof);
@@ -1022,11 +1023,6 @@ void OF_Serial::SerialProcessingDocked()
                             FW_Common::CameraSet();
                             FW_Common::FeedbackSet();
                             
-                            // Update bindings so LED/Pixel changes are reflected immediately
-                            if(OF_Prefs::usb.devicePID >= 1 && OF_Prefs::usb.devicePID <= 4) {
-                                playerStartBtn = OF_Prefs::usb.devicePID + '0';
-                                playerSelectBtn = OF_Prefs::usb.devicePID + '0' + 4;
-                            }
                             FW_Common::UpdateBindings(OF_Prefs::toggles[OF_Const::lowButtonsMode]);
 
                         #ifdef LED_ENABLE
@@ -1064,9 +1060,10 @@ void OF_Serial::SerialProcessingDocked()
                         }
                         rxLen += Serial.readBytes(&RXbuf[rxLen], datSize);
                         switch(type) {
-                            case OF_Const::sCommitToggles:  SerialBatchRecv(RXbuf, OF_Prefs::toggles,  OF_Prefs::OFPresets.boolTypes_Strings,     sizeof(OF_Prefs::toggles)  / OF_Const::boolTypesCount,     datSize, rxLen); break;
-                            case OF_Const::sCommitPins:     SerialBatchRecv(RXbuf, OF_Prefs::pins,     OF_Prefs::OFPresets.boardInputs_Strings,   sizeof(OF_Prefs::pins)     / OF_Const::boardInputsCount,   datSize, rxLen); break;
-                            case OF_Const::sCommitSettings: SerialBatchRecv(RXbuf, OF_Prefs::settings, OF_Prefs::OFPresets.settingsTypes_Strings, sizeof(OF_Prefs::settings) / OF_Const::settingsTypesCount, datSize, rxLen); break;
+                            case OF_Const::sCommitToggles:  SerialBatchRecv(RXbuf, OF_Prefs::toggles,           OF_Prefs::OFPresets.boolTypes_Strings,     sizeof(OF_Prefs::toggles)          / OF_Const::boolTypesCount,     datSize, rxLen); break;
+                            case OF_Const::sCommitPins:     SerialBatchRecv(RXbuf, OF_Prefs::pins,              OF_Prefs::OFPresets.boardInputs_Strings,   sizeof(OF_Prefs::pins)             / OF_Const::boardInputsCount,   datSize, rxLen); break;
+                            case OF_Const::sCommitSettings: SerialBatchRecv(RXbuf, OF_Prefs::settings,          OF_Prefs::OFPresets.settingsTypes_Strings, sizeof(OF_Prefs::settings)         / OF_Const::settingsTypesCount, datSize, rxLen); break;
+                            case OF_Const::sCommitBtns:     SerialBatchRecv(RXbuf, OF_Prefs::backupButtonDesc,  OF_Prefs::OFPresets.boardInputs_Strings,   sizeof(OF_Prefs::backupButtonDesc) / ButtonCount,                  datSize, rxLen); break;
                             case OF_Const::sCommitProfile:
                                 if(profNum < PROFILE_COUNT) SerialBatchRecv(RXbuf,
                                                                             &OF_Prefs::profiles[profNum],
@@ -1128,6 +1125,7 @@ void OF_Serial::SerialBatchSend(void *dataPtr, const std::unordered_map<std::str
                     }
                 }
             } else {
+                if(dataPtr == OF_Prefs::backupButtonDesc && pair.second >= ButtonCount-1) continue;
                 TXbuf[pos++] = dataSize;
                 memcpy(&TXbuf[pos], (uint8_t*)dataPtr + (dataSize * pair.second), dataSize);
                 pos += dataSize;

--- a/libraries/LightgunButtons/LightgunButtons.cpp
+++ b/libraries/LightgunButtons/LightgunButtons.cpp
@@ -181,7 +181,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.press(btn.reportCode3);
                                     } else {
                                         bitSet(padMask, btn.reportCode3-15);
-                                        Gamepad16.padUpdate(PadMaskConvert());
+                                        Gamepad16.padUpdate(PadMaskConvert(padMask));
                                     }
                                 }
                             } else if(offScreen) {
@@ -195,7 +195,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.press(btn.reportCode2);
                                     } else {
                                         bitSet(padMask, btn.reportCode2-15);
-                                        Gamepad16.padUpdate(PadMaskConvert());
+                                        Gamepad16.padUpdate(PadMaskConvert(padMask));
                                     }
                                 }
                             } else {
@@ -208,7 +208,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.press(btn.reportCode);
                                     } else {
                                         bitSet(padMask, btn.reportCode-15);
-                                        Gamepad16.padUpdate(PadMaskConvert());
+                                        Gamepad16.padUpdate(PadMaskConvert(padMask));
                                     }
                                 }
                             }
@@ -237,7 +237,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.release(btn.reportCode3);
                                     } else {
                                         bitClear(padMask, btn.reportCode3-15);
-                                        Gamepad16.padUpdate(PadMaskConvert());
+                                        Gamepad16.padUpdate(PadMaskConvert(padMask));
                                     }
                                 }
                             } else if(bitRead(internalOffscreenMask, i)) {
@@ -251,7 +251,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.release(btn.reportCode2);
                                     } else {
                                         bitClear(padMask, btn.reportCode2-15);
-                                        Gamepad16.padUpdate(PadMaskConvert());
+                                        Gamepad16.padUpdate(PadMaskConvert(padMask));
                                     }
                                 }
                             } else {
@@ -264,7 +264,7 @@ uint32_t LightgunButtons::Poll(unsigned long minTicks)
                                         Gamepad16.release(btn.reportCode);
                                     } else {
                                         bitClear(padMask, btn.reportCode-15);
-                                        Gamepad16.padUpdate(PadMaskConvert());
+                                        Gamepad16.padUpdate(PadMaskConvert(padMask));
                                     }
                                 }
                             }
@@ -325,9 +325,9 @@ uint32_t LightgunButtons::Repeat()
     return repeat;
 }
 
-uint32_t LightgunButtons::PadMaskConvert()
+uint32_t LightgunButtons::PadMaskConvert(const uint32_t &mask)
 {
-    switch(padMask) {
+    switch(mask) {
         case 1: // 0x00000001
             return GAMEPAD_HAT_UP;
             break;

--- a/libraries/LightgunButtons/LightgunButtons.h
+++ b/libraries/LightgunButtons/LightgunButtons.h
@@ -149,6 +149,11 @@ public:
     /// @brief Get the button index from a mask or -1 if a single button is not matched
     static int MaskToIndex(uint32_t mask);
 
+    /// @brief Converts directional buttons bit mask from internal to HID format.
+    /// @details Because the HID POV hat format makes no effing sense whatsoever.
+    /// @returns Converted D-Pad mask
+    uint32_t PadMaskConvert(const uint32_t &);
+
 private:
     /// @brief millis() value from last Poll
     unsigned long lastMillis;
@@ -174,11 +179,6 @@ private:
     /// @brief Internal bit mask of directional buttons pressed.
     /// @details Only the four rightmost bits are used to track state of gamepad directional buttons pressed.
     uint32_t padMask = 0;
-
-    /// @brief Converts directional buttons bit mask from internal to HID format.
-    /// @details Because the HID POV hat format makes no effing sense whatsoever.
-    /// @returns Converted D-Pad mask
-    uint32_t PadMaskConvert();
 
     /// @brief Tracked buttons that are offscreen.
     uint32_t internalOffscreenMask;


### PR DESCRIPTION
Relies on newest App version (TeamOpenFIRE/OpenFIRE-App#72) to expose these settings.
Initial ButtonsDesc defined in `OpenFIREprefs.h` is now copied to the backbuffer introduced in #97 (and subsequently saved), and new methods directly read and write to this backbuffer. When reloading inputs map, this backbuffer is used for updating the main ButtonsDesc array. This (finally) closes #27 (without manually editing the descriptor in-code).

The `playerStartBtn`/`playerSelectBtn` blobs are now more context-sensitive - by using the filler `0xFF`/`0xFE` bytes respectively for Keyboard codes, the firmware will fill in what button this should be when updating bindings.

`btnHome` is intentionally not able to be updated atm, as it's meant for purely firmware navigation.

Also adds a new setting for determining the mode that an Analog Stick (if both axis are connected) can output as; defaults to the stock Gamepad Analog Stick mode, but can be set to the Gamepad D-Pad and Keyboard Arrow Keys. Figured that this might be useful for someone who prefers it. The deadzone is still fixed, but the effective DZ size is appropriately upsized to make it less sensitive.