### PR TITLE
Fix completely arbitrary delay when docking on first boot because I don't even remember anymore

### DIFF
--- a/OpenFIREmain/OpenFIREmain.ino
+++ b/OpenFIREmain/OpenFIREmain.ino
@@ -827,12 +827,7 @@ void ExecRunModeProcessing()
 void ExecGunModeDocked()
 {
     FW_Common::buttons.ReportDisable();
-
-    if(FW_Common::justBooted) {
-        // center the joystick so RetroArch/Windows doesn't throw a hissy fit about uncentered joysticks
-        delay(250);  // Exact time needed to wait seems to vary, so make a safe assumption here.
-        Gamepad16.releaseAll();
-    }
+    FW_Common::buttons.ReleaseAll();
 
     #ifdef LED_ENABLE
         OF_RGB::LedUpdate(127, 127, 255);


### PR DESCRIPTION
It would be better that it release all inputs, not just the gamepad's here, too. :)