### PR TITLE
Refine how Serial-signalled button re-mappings work

### DIFF
--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -1096,25 +1096,10 @@ void FW_Common::UpdateBindings(const bool &lowButtons)
     }
     #endif // PLAYER_NUMBER
 
-    for(int i = 0; i < ButtonCount; ++i) {
+    for(int i = 0; i < ButtonCount; ++i)
         memcpy(&LightgunButtons::ButtonDesc[i].reportType,
                OF_Prefs::backupButtonDesc[i],
                sizeof(OF_Prefs::backupButtonDesc[0]));
-        
-        while(true) {
-            uint8_t *ptr = (uint8_t*)memchr(&LightgunButtons::ButtonDesc[i].reportCode, 0xFF, sizeof(OF_Prefs::backupButtonDesc[i]-1));
-            if(ptr != nullptr)
-                *ptr = playerStartBtn;
-            else break;
-        }
-
-        while(true) {
-            uint8_t *ptr = (uint8_t*)memchr(&LightgunButtons::ButtonDesc[i].reportCode, 0xFE, sizeof(OF_Prefs::backupButtonDesc[i]-1));
-            if(ptr != nullptr)
-                *ptr = playerSelectBtn;
-            else break;
-        }
-    }
 
     // Updates button functions for low-button mode
     if(lowButtons) {
@@ -1124,5 +1109,25 @@ void FW_Common::UpdateBindings(const bool &lowButtons)
         memcpy(&LightgunButtons::ButtonDesc[FW_Const::BtnIdx_B].reportType2,
                OF_Prefs::backupButtonDesc[FW_Const::BtnIdx_Select],
                2);
+    }
+
+    UpdateStartSelect();
+}
+
+void FW_Common::UpdateStartSelect()
+{
+    uint8_t *btnMatchedPtr;
+    for(int i = 0; i < ButtonCount; ++i) {
+        do {
+            btnMatchedPtr = (uint8_t*)memchr(&LightgunButtons::ButtonDesc[i].reportCode, 0xFF, sizeof(OF_Prefs::backupButtonDesc[i]-1));
+            if(btnMatchedPtr != nullptr)
+                *btnMatchedPtr = playerStartBtn;
+        } while(btnMatchedPtr != nullptr);
+
+        do {
+            btnMatchedPtr = (uint8_t*)memchr(&LightgunButtons::ButtonDesc[i].reportCode, 0xFE, sizeof(OF_Prefs::backupButtonDesc[i]-1));
+            if(btnMatchedPtr != nullptr)
+                *btnMatchedPtr = playerSelectBtn;
+        } while(btnMatchedPtr != nullptr);
     }
 }

--- a/OpenFIREmain/OpenFIREcommon.h
+++ b/OpenFIREmain/OpenFIREcommon.h
@@ -113,6 +113,9 @@ public:
     ///           but these are handled directly in firing modes currently.
     static void UpdateBindings(const bool &lowButtons = false);
 
+    /// @brief    Checks Button Descriptor and replaces instances of 0xFF/0xFE with player-relative Start/Select
+    static void UpdateStartSelect();
+
     // initial gunmode
     static inline FW_Const::GunMode_e gunMode = FW_Const::GunMode_Init;
 

--- a/OpenFIREmain/OpenFIREserial.cpp
+++ b/OpenFIREmain/OpenFIREserial.cpp
@@ -112,7 +112,14 @@ void OF_Serial::SerialProcessing()
                     case '3':
                     // disabled
                     case '0':
-                      FW_Common::UpdateBindings(OF_Prefs::toggles[OF_Const::lowButtonsMode]);
+                      memcpy(&LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Trigger].reportType2,
+                             &OF_Prefs::backupButtonDesc[FW_Const::BtnIdx_Trigger][2],
+                             sizeof(LightgunButtons::Desc_s::reportType)*2);
+                      // reset remapping for low button users if M1x2 was previously called
+                      if(OF_Prefs::toggles[OF_Const::lowButtonsMode])
+                          memcpy(&LightgunButtons::ButtonDesc[FW_Const::BtnIdx_A].reportType,
+                                 OF_Prefs::backupButtonDesc[FW_Const::BtnIdx_A],
+                                 sizeof(LightgunButtons::Desc_s::reportType)*2);
                       break;
                     // offscreen button
                     case '2':
@@ -126,6 +133,7 @@ void OF_Serial::SerialProcessing()
                                  sizeof(LightgunButtons::Desc_s::reportType)*2);
                       break;
                 }
+                FW_Common::UpdateStartSelect();
                 break;
               // pedal functionality
               case '2':
@@ -133,7 +141,9 @@ void OF_Serial::SerialProcessing()
                 switch(Serial.read()) {
                     // separate button (default to original binds)
                     case '0':
-                      FW_Common::UpdateBindings(OF_Prefs::toggles[OF_Const::lowButtonsMode]);
+                      memcpy(&LightgunButtons::ButtonDesc[FW_Const::BtnIdx_Pedal].reportType,
+                             OF_Prefs::backupButtonDesc[FW_Const::BtnIdx_Pedal],
+                             sizeof(OF_Prefs::backupButtonDesc[0]));
                       break;
                     // make reload button (mapping of Button A)
                     case '1':
@@ -148,6 +158,7 @@ void OF_Serial::SerialProcessing()
                              sizeof(OF_Prefs::backupButtonDesc[0]));
                       break;
                 }
+                FW_Common::UpdateStartSelect();
                 break;
               // aspect ratio correction
               case '3':


### PR DESCRIPTION
Start/Select in-place updates is a macro used after `M1x` and `M2x` commands.

Only do a full button desc reset on `E`nd commands; just do small backbuffer copies instead and then check Start/Select afterwards.