### PR TITLE
Bump backend systems to add RP2350 support

### DIFF
--- a/.github/workflows/arduino-cli-builds.yml
+++ b/.github/workflows/arduino-cli-builds.yml
@@ -15,26 +15,28 @@ jobs:
             pretty: rpipico
             flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
             
-          #- name: Raspberry Pi Pico W (USB)
+          - name: Raspberry Pi Pico W (USB)
+            fqbn: rpipicow
+            pretty: rpipicow-noBT
+            flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3,wificountry=worldwide,ipbtstack=ipv4only
+
+          # Disabled until issues surrounding interacting with cyw southbridge causing lockups is solved
+          #- name: Raspberry Pi Pico W (Bluetooth)
           #  fqbn: rpipicow
-          #  pretty: rpipicow-noBT
-          #  flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
+          #  pretty: rpipicow-btBETA
+          #  flags: freq=133,usbstack=tinyusb,opt=Optimize3,ipbtstack=ipv4btcble,wificountry=worldwide
 
           - name: Raspberry Pi Pico 2 [ARM]
             fqbn: rpipico2
             pretty: rpipico2
             flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
 
+          # For whatever reason, building for 2W is being fickle atm
           #- name: Raspberry Pi Pico 2W [ARM] (USB)
           #  fqbn: rpipico2w
           #  pretty: rpipico2w
-          #  flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
-            
-          #- name: Raspberry Pi Pico W (Bluetooth)
-          #  fqbn: rpipicow
-          #  pretty: rpipicow-btBETA
-          #  flags: freq=133,usbstack=tinyusb,opt=Optimize3,ipbtstack=ipv4btcble,wificountry=worldwide
-            
+          #  flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,wificountry=worldwide,ipbtstack=ipv4only,arch=arm
+
           - name: Adafruit ItsyBitsy RP2040
             fqbn: adafruit_itsybitsy
             pretty: adafruitItsy

--- a/.github/workflows/arduino-cli-builds.yml
+++ b/.github/workflows/arduino-cli-builds.yml
@@ -69,8 +69,10 @@ jobs:
         if: ${{ matrix.fqbn == 'arduino_nano_connect' }}
         run: arduino-cli lib install WiFiNINA
         
+      # use our fork with patched TUSB
+      # TODO: for now, select version manually (as our -tusb version is currently considered prior to upstream 4.5.4)
       - name: Setting up Arduino-cli
-        run: arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/SeongGino/arduino-pico/releases/download/3.9.2-fix/package_rp2040_fix_index_orig.json
+        run: arduino-cli core install rp2040:rp2040@4.5.4-tusb --additional-urls https://github.com/TeamOpenFIRE/arduino-pico/releases/download/global/package_rp2040_index.json
 
       - name: Get short SHA
         id: get-short-sha

--- a/.github/workflows/arduino-cli-builds.yml
+++ b/.github/workflows/arduino-cli-builds.yml
@@ -15,20 +15,20 @@ jobs:
             pretty: rpipico
             flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
             
-          - name: Raspberry Pi Pico W (USB)
-            fqbn: rpipicow
-            pretty: rpipicow-noBT
-            flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
+          #- name: Raspberry Pi Pico W (USB)
+          #  fqbn: rpipicow
+          #  pretty: rpipicow-noBT
+          #  flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
 
           - name: Raspberry Pi Pico 2 [ARM]
             fqbn: rpipico2
             pretty: rpipico2
             flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
 
-          - name: Raspberry Pi Pico 2W [ARM] (USB)
-            fqbn: rpipico2w
-            pretty: rpipico2w
-            flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
+          #- name: Raspberry Pi Pico 2W [ARM] (USB)
+          #  fqbn: rpipico2w
+          #  pretty: rpipico2w
+          #  flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
             
           #- name: Raspberry Pi Pico W (Bluetooth)
           #  fqbn: rpipicow
@@ -59,6 +59,11 @@ jobs:
             fqbn: waveshare_rp2040_zero
             pretty: waveshareZero
             flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
+
+          - name: Generic RP2350
+            fqbn: generic-rp2350
+            pretty: generic-rp2350
+            flags: freq=133,usbstack=tinyusb,flash=2097152_1048576,opt=Optimize3,arch=arm
             
           - name: Generic RP2040
             fqbn: generic

--- a/.github/workflows/arduino-cli-builds.yml
+++ b/.github/workflows/arduino-cli-builds.yml
@@ -19,6 +19,16 @@ jobs:
             fqbn: rpipicow
             pretty: rpipicow-noBT
             flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
+
+          - name: Raspberry Pi Pico 2 [ARM]
+            fqbn: rpipico2
+            pretty: rpipico2
+            flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
+
+          - name: Raspberry Pi Pico 2W [ARM] (USB)
+            fqbn: rpipico2w
+            pretty: rpipico2w
+            flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
             
           #- name: Raspberry Pi Pico W (Bluetooth)
           #  fqbn: rpipicow

--- a/.github/workflows/arduino-cli-builds.yml
+++ b/.github/workflows/arduino-cli-builds.yml
@@ -19,23 +19,25 @@ jobs:
             fqbn: rpipicow
             pretty: rpipicow-noBT
             flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3,wificountry=worldwide,ipbtstack=ipv4only
+            extra_flags: -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1
 
           # Disabled until issues surrounding interacting with cyw southbridge causing lockups is solved
           #- name: Raspberry Pi Pico W (Bluetooth)
           #  fqbn: rpipicow
           #  pretty: rpipicow-btBETA
-          #  flags: freq=133,usbstack=tinyusb,opt=Optimize3,ipbtstack=ipv4btcble,wificountry=worldwide
+          #  flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3,ipbtstack=ipv4btcble,wificountry=worldwide
+          #  extra_flags: -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1
 
           - name: Raspberry Pi Pico 2 [ARM]
             fqbn: rpipico2
             pretty: rpipico2
             flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,arch=arm
 
-          # For whatever reason, building for 2W is being fickle atm
-          #- name: Raspberry Pi Pico 2W [ARM] (USB)
-          #  fqbn: rpipico2w
-          #  pretty: rpipico2w
-          #  flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,wificountry=worldwide,ipbtstack=ipv4only,arch=arm
+          - name: Raspberry Pi Pico 2W [ARM] (USB)
+            fqbn: rpipico2w
+            pretty: rpipico2w
+            flags: freq=133,usbstack=tinyusb,flash=4194304_65536,opt=Optimize3,wificountry=worldwide,ipbtstack=ipv4only,arch=arm
+            extra_flags: -DPICO_CYW43_SUPPORTED=1 -DCYW43_PIN_WL_DYNAMIC=1
 
           - name: Adafruit ItsyBitsy RP2040
             fqbn: adafruit_itsybitsy
@@ -102,7 +104,8 @@ jobs:
           OpenFIREmain
           --libraries libraries
           --build-property 'build.extra_flags=
-          -DGIT_HASH="${{steps.get-short-sha.outputs.id}}"'
+          -DGIT_HASH="${{steps.get-short-sha.outputs.id}}"
+          ${{matrix.extra_flags}}'
         
       - name: Rename build file
         run: cp ${{github.workspace}}/OpenFIREmain/build/rp2040.rp2040.${{matrix.fqbn}}/OpenFIREmain.ino.uf2 OpenFIREfw.${{ matrix.pretty }}.uf2

--- a/.github/workflows/arduino-cli-builds.yml
+++ b/.github/workflows/arduino-cli-builds.yml
@@ -61,8 +61,8 @@ jobs:
             flags: freq=133,usbstack=tinyusb,flash=2097152_65536,opt=Optimize3
 
           - name: Generic RP2350
-            fqbn: generic-rp2350
-            pretty: generic-rp2350
+            fqbn: generic_rp2350
+            pretty: generic_rp2350
             flags: freq=133,usbstack=tinyusb,flash=2097152_1048576,opt=Optimize3,arch=arm
             
           - name: Generic RP2040

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -12,21 +12,21 @@ For most people, you may prefer editing, testing and using the Arduino IDE. This
  1. [Download and install the Arduino IDE for your system]() (or for Linux users, install from your system's package manager).
  2. After opening the IDE, go to File->Preferences and paste the following into the *Additional boards manager URLs* field:
  ```
- https://github.com/SeongGino/arduino-pico/releases/download/3.9.2-fix/package_rp2040_fix_index_orig.json
+ https://github.com/TeamOpenFIRE/arduino-pico/releases/download/global/package_rp2040_index.json
  ```
- 3. Open the Boards Manager (second button from the top on the left sidebar), search and install "Raspberry Pi Pico/RP2040 (Fix)" version `3.9.2-fix`.
+ 3. Open the Boards Manager (second button from the top on the left sidebar), search and install the latest version of *"Raspberry Pi Pico/RP2040/RP2350 (TUSB Fix)"*.
     - Using this fork is REQUIRED as it includes a fixed version of Adafruit's TinyUSB library. Until adafruit/Adafruit_TinyUSB_Arduino#293 is resolved, do not use the upstream *Arduino-Pico* core or install the separate Adafruit TinyUSB library.
  4. Clone/extract the contents of the source repository into your system's `Arduino` folder, so that the `OpenFIREmain` folder is next to `libraries`. Open the `OpenFIREmain` sketch.
- 5. From the app menu up top, set the current microcontroller to your current board under *Tools->Board:->Raspberry Pi Pico/RP2040 (Fix),* set CPU speed to *133 MHz,* set Optimize to *Optimize Even More (-O3),* set Flash Size to include a 64KB file system,* and set USB Stack to *Adafruit TinyUSB* (not *Host*).
+ 5. From the app menu up top, set the current microcontroller to your current board under *Tools->Board:->Raspberry Pi Pico/RP2040/RP2350 (TUSB Fix),* set CPU speed to *133 MHz,* set Optimize to *Optimize Even More (-O3),* set Flash Size to include at least a 64KB file system,* and set USB Stack to *Adafruit TinyUSB* (not *Host*). For RP2350 boards, *CPU Architecture* must be set to *ARM*.
  6. When you're ready to build, click Verify to check for compilation errors, Upload to directly upload the binary to the microcontroller (if connected), or go to *Sketch->Export Compiled Binary* to generate a .uf2 file under `OpenFIREmain/build/rp2040.rp2040.board_name` that you can drag and drop onto your microcontroller when it's in bootloader mode (either by holding BOOTSEL on poweron, or resetting to bootloader from the OpenFIRE App).
 
 ### Arduino (-cli) Setup
 Compiling from the cli can be used to automate the build process, and is used by the GitHub actions deployments for release builds.
  1. [Download the Arduino-cli tool for your system](https://github.com/arduino/arduino-cli/releases/latest) and install it to where it's most convenient (or for Linux users, install from your system's package manager).
     - These instructions are tailored to Linux, but Windows users can use `arduino-cli.exe` whenever the tool is referenced.
- 2. Install the patched RP2040 core for OpenFIRE:
+ 2. Install the latest version of the patched RP2040/RP2350 core for OpenFIRE:
     ```bash
-    $ arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/SeongGino/arduino-pico/releases/download/3.9.2-fix/package_rp2040_fix_index_orig.json
+    $ arduino-cli core install rp2040:rp2040 --additional-urls https://github.com/TeamOpenFIRE/arduino-pico/releases/download/global/package_rp2040_index.json
     ```
     - Optional: for *Arduino Nano RP2040 Connect*, also install its WiFiNINA library:
       ```bash
@@ -49,7 +49,7 @@ Compiling from the cli can be used to automate the build process, and is used by
     Adafruit Feather RP2040 RFM          rp2040:rp2040:adafruit_feather_rfm
     ...
     ```
- 5. Find the flash value that allocates 64KB for the File System (replacing `{BOARD}` with your desired microcontroller's FQBN name). The example output below would be seen if `{BOARD}` was set to `rp2040:rp2040:rpipico`:
+ 5. Find the flash value that allocates at least 64KB for the File System (replacing `{BOARD}` with your desired microcontroller's FQBN name). The example output below would be seen if `{BOARD}` was set to `rp2040:rp2040:rpipico`:
     ```bash
     $ arduino-cli board details -b {BOARD}
 
@@ -67,7 +67,6 @@ Compiling from the cli can be used to automate the build process, and is used by
     ```bash
     $ arduino-cli compile -e --fqbn rp2040:rp2040:{BOARD}:usbstack=tinyusb,opt=Optimize3,flash={FLASH} /path/to/OpenFIRE-Firmware/OpenFIREmain --libraries /path/to/repo/libraries
     ```
-    *for custom builds, feel free to configure the above build flags to your needs to enable/disable certain OpenFIREfw features.*
     
 When successful, you will find the exported binary at `/path/to/OpenFIRE-Firmware/OpenFIREmain/build/rp2040.rp2040.{BOARD}/OpenFIREmain.ino.uf2`
 
@@ -77,9 +76,9 @@ Per-board build configurations for various microcontrollers, and the strings to 
 ### Define Buttons & Timers
 Tactile extras can be defined/unset by simply (un)commenting the respective defines in `OpenFIREDefines.h` - though each one of these can be simply disabled at runtime even when the firmware is "fully kitted".
 
-If your gun is going to be hardset to player 1/2/3/4 e.g. for an arcade build, change `#define PLAYER_NUMBER` to 1, 2, 3, or 4 depending on what keys you want the Start/Select buttons to correlate to. Remember that guns can be remapped to any player number arrangement at any time if needed by sending an `XR#` command over Serial - where # is the player number.
+If your gun is going to be hardset to player 1/2/3/4 e.g. for an arcade build, uncomment and set `#define PLAYER_NUMBER` to 1, 2, 3, or 4 depending on what keys you want the Start/Select buttons to correlate to. Remember that, when this variable is unset, guns can be remapped to any player number arrangement at any time if needed by sending an `XR#` command over Serial - where # is the player number.
 
-These parameters are easily found and can be redefined in `OpenFIREDefines.h`:
+To change the default USB ID, these parameters are easily found and can be redefined in `OpenFIREDefines.h`:
 
 ```c++
 #define MANUFACTURER_NAME "OpenFIRE"
@@ -88,8 +87,9 @@ These parameters are easily found and can be redefined in `OpenFIREDefines.h`:
 ```
 
 You may change these to suit whatever your heart desires - though the only parts *necessary to change for multiplayer* is the Device Vendor ID and/or Product ID (the latter is determined by either loaded preferences or Player Number, in that order). Then, just reflash the board!
+Keep in mind that for App and most distros' compatibility, the Vendor ID (`DEVICE_VID`) **MUST** be kept at the default `0xF143` identifier.
 
 Remember that the sketch uses the Arduino GPIO pin numbers; on many boards, including the Raspberry Pi Pico and the Adafruit Itsybitsy RP2040, these are the silkscreen labels on the **underside** of the microcontroller (marked GP00-29). Note that this does not apply to the analog pins (A0-A3), which are macros for GP26-29.
-For boards already implemented, the OpenFIRE Desktop App has an embedded interactive *boards previewer* to view the default layout and location of GPIO for supported microcontrollers. You can also refer to [this interactive webpage](https://pico.pinout.xyz/) for detailed information on the Pico/W's layout, or your board vendor's documentation for more information about your particular microcontroller.
+For boards already implemented, the OpenFIRE Desktop App has an embedded interactive *boards previewer* to view the default layout, location, and extra capabilities of GPIO for supported microcontrollers. You can also refer to [this interactive webpage](https://pico.pinout.xyz/) for detailed information on the Pico/W's layout, or your board vendor's documentation for more information about your particular microcontroller.
 
 The default button:pins layout used will be reflected by default in the OpenFIRE App, which can be used as reference or can be changed to any custom pins layout to suit your needs - custom settings will take priority over board defaults if enabled & detected.


### PR DESCRIPTION
We now use an updated `arduino-core` fork which is currently up-to-date with upstream, just with the TinyUSB patch added. This allows for building for RP2350 systems!
Code seems to build OK for Pico 2 and 2W, and should work with the latest App code.

Documentation is updated to take this updated fork into account, as well as reflect the current functionality of the `PLAYER_NUMBER` define which is commented out by default.