### PR TITLE
Update OpenFIREcommon.cpp - assign OLED.display pointer to nullptr

### DIFF
--- a/OpenFIREmain/OpenFIREcommon.cpp
+++ b/OpenFIREmain/OpenFIREcommon.cpp
@@ -92,9 +92,14 @@ void FW_Common::FeedbackSet()
         // wrapper will manage display validity
         // check it's not using the camera's I2C line
         if(OF_Prefs::toggles[OF_Const::i2cOLED]) {
-            if(!OLED.Begin()) { if(OLED.display != nullptr) delete OLED.display; }
+            if(!OLED.Begin()) { 
+                if(OLED.display != nullptr) {
+                    delete OLED.display; 
+                    OLED.display = nullptr; 
+                }
+            }
         }
-    #endif // USES_DISPLAY
+     #endif // USES_DISPLAY
     }
 }
 


### PR DESCRIPTION
By assigning the OLED.display pointer to nullptr, the program works and the micro doesn't crash, even if the OLED display is not connected even if the pins are configured.
...
This probably solves the problem you describe in OpenFIREdisplay.cpp on line 29 " // TODO: for some reason, doing this AFTER saving updated pins settings (even when doing it from defaults and there's no default mappings for peripheral pins) 
// causes the board to hang. Even though this is all correct (and any display objects should get deleted from the above, so don't think it can be a new object thing)...
"