### PR TITLE
Added detection and handling of faulty temperature sensor.

### DIFF
--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -149,7 +149,7 @@ void OF_FFB::TemperatureUpdate()
     currentMillis = millis();
     if(currentMillis - previousMillisTemp > TEMP_UPDATE_INTERVAL) {
         previousMillisTemp = currentMillis;
-        auto analogValue = analogRead(OF_Prefs::pins[OF_Const::tempPin]);
+        unsigned int analogValue = analogRead(OF_Prefs::pins[OF_Const::tempPin]);
         if (analogValue < 100 || analogValue > 2500) {
             // Out of range reading, set to fatal value. Ranges out of 100-2500 correspond to
             // -40°C to 150°C which is outside the expected operating range :)

--- a/OpenFIREmain/OpenFIREFeedback.cpp
+++ b/OpenFIREmain/OpenFIREFeedback.cpp
@@ -149,7 +149,20 @@ void OF_FFB::TemperatureUpdate()
     currentMillis = millis();
     if(currentMillis - previousMillisTemp > TEMP_UPDATE_INTERVAL) {
         previousMillisTemp = currentMillis;
-        temperatureGraph[tempGraphIndex] = (((analogRead(OF_Prefs::pins[OF_Const::tempPin]) * 3.3) / 4096) - 0.5) * 100; // Convert reading from mV->3.3->12-bit->Celsius
+        auto analogValue = analogRead(OF_Prefs::pins[OF_Const::tempPin]);
+        if (analogValue < 100 || analogValue > 2500) {
+            // Out of range reading, set to fatal value. Ranges out of 100-2500 correspond to
+            // -40°C to 150°C which is outside the expected operating range :)
+            // This case can happen if the sensor is faulty or the µC ADC is malfunctioning.
+            // In case no sensor is connected the pin is floating and may read out-of-range values but
+            // mostly return low values which makes it impossible to detect a disconnected sensor by
+            // simple thresholding.
+            tempStatus = Temp_Fatal;
+            temperatureCurrent = OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE; // Set to a high temp to reflect error.
+            return;
+        }
+
+        temperatureGraph[tempGraphIndex] = (((analogValue * 3.3) / 4096) - 0.5) * 100; // Convert reading from mV->3.3->12-bit->Celsius
         if(tempGraphIndex < 3) {
             tempGraphIndex++;
         } else {
@@ -159,7 +172,14 @@ void OF_FFB::TemperatureUpdate()
                                   temperatureGraph[1] +
                                   temperatureGraph[2] +
                                   temperatureGraph[3]) >> 2;
-                                  
+
+            if (temperatureCurrent > OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE) {
+              // Cap the temperature to avoid issues with faulty readings.
+              // This leads to Temp_Fatal state which is the safest option.
+              // This also prevents issues with unsigned int underflow in the tempStatus checks below.
+              temperatureCurrent = OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE;
+            }
+
             if(tempStatus == Temp_Fatal) {
                 if(temperatureCurrent < OF_Prefs::settings[OF_Const::tempShutdown]-5)
                     tempStatus = Temp_Warning;

--- a/OpenFIREmain/OpenFIREdisplay.cpp
+++ b/OpenFIREmain/OpenFIREdisplay.cpp
@@ -214,7 +214,11 @@ void ExtDisplay::IdleOps()
 #ifdef USES_TEMP
 void ExtDisplay::ShowTemp()
 {
-    if(OF_FFB::temperatureCurrent < 10) {
+    if (OF_FFB::temperatureCurrent == OF_Const::TEMPERATURE_SENSOR_ERROR_VALUE) {
+      // Analog read maxed out, likely disconnected/temp sensor fault
+      TopPanelUpdate("Temp sensor: ", "Fault!");
+      return;
+    } else if(OF_FFB::temperatureCurrent < 10) {
         tempString[0] = OF_FFB::temperatureCurrent + '0';
         tempString[1] = ' ';
         tempString[2] = 'C';


### PR DESCRIPTION
This pull request introduces improvements to the temperature sensor error handling and display logic, making the system more robust against sensor faults and out-of-range readings. The changes ensure that faulty or disconnected sensors are detected reliably and that the user interface clearly indicates sensor errors.

**Temperature sensor error handling:**
* Added explicit range checks for analog readings in `TemperatureUpdate()` to detect sensor faults and set `tempStatus` to `Temp_Fatal` when readings are outside the expected range (100–2500), assigning a designated error value to `temperatureCurrent`.
* Added logic to cap `temperatureCurrent` at the error value if it exceeds the allowed maximum, preventing underflow and ensuring safe state transitions.

**User interface improvements:**
* Updated `ShowTemp()` to display "Fault!" on the top panel when a sensor error is detected, improving clarity for users and distinguishing between low temperature and sensor faults.

**ATTENTION:**
This PR requires the following PR merged before (will update submodule once boards is merged):
https://github.com/TeamOpenFIRE/OpenFIRE-Boards/pull/11